### PR TITLE
Fix keyword cleaning in frontmatter cleanup

### DIFF
--- a/markdown_frontmatter_cleanup.py
+++ b/markdown_frontmatter_cleanup.py
@@ -38,8 +38,8 @@ def clean_tags(frontmatter: dict) -> dict:
     return frontmatter
 
 def clean_keywords(frontmatter: dict) -> dict:
-    # Ensure the 'tags' key has unique elements, capitalizing the first letter
-    if 'keywords' in frontmatter and isinstance(frontmatter['tags'], list):
+    # Ensure the 'keywords' key has unique elements, capitalizing the first letter
+    if 'keywords' in frontmatter and isinstance(frontmatter['keywords'], list):
         # Normalize by capitalizing the first letter of each tag and removing duplicates (case-insensitive)
         unique_tags = set()  # To ensure uniqueness
         cleaned_tags = []


### PR DESCRIPTION
## Summary
- reference `frontmatter['keywords']` in `clean_keywords`
- keep keywords unique and capitalized

## Testing
- `python -m py_compile markdown_frontmatter_cleanup.py`

------
https://chatgpt.com/codex/tasks/task_e_6842edce178c8325b5ea5e1c2acb06ef