### PR TITLE
Add CLI path option for Python tools

### DIFF
--- a/capitalized_keywords.py
+++ b/capitalized_keywords.py
@@ -1,9 +1,10 @@
 import os
 import yaml
 import re
+import argparse
 
-# Define the folder where the markdown files are stored
-folder_path = './_posts'  # Change this to your folder path
+# Default folder containing the markdown files
+DEFAULT_FOLDER = "./_posts"
 
 # List of stop words to exclude from capitalization
 stop_words = {'at', 'vs', 'and', 'or', 'the', 'of', 'in', 'on', 'for', 'to', 'a'}
@@ -71,11 +72,14 @@ def process_markdown_file(file_path):
         print(f"No 'keywords' found in {file_path}")
 
 # Function to process all markdown files in the folder
-def process_all_markdown_files(folder_path):
+def process_all_markdown_files(folder_path: str) -> None:
     for filename in os.listdir(folder_path):
         if filename.endswith(".md"):  # Check if it's a markdown file
             file_path = os.path.join(folder_path, filename)
             process_markdown_file(file_path)
 
-# Run the function for the specified folder
-process_all_markdown_files(folder_path)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Capitalize keywords in markdown files")
+    parser.add_argument("--path", default=DEFAULT_FOLDER, help="Target folder")
+    args = parser.parse_args()
+    process_all_markdown_files(args.path)

--- a/check_summary.py
+++ b/check_summary.py
@@ -1,5 +1,6 @@
 import os
 import yaml  # to parse YAML front matter
+import argparse
 
 def extract_front_matter(md_file_path: str) -> dict:
     """
@@ -52,7 +53,9 @@ def check_front_matter(folder_path: str, output_file: str):
                         out_file.write(f"  - Keywords present: {has_keywords}\n")
                         out_file.write("\n")
 
-# Example usage
-folder_path = './_posts'  # Replace with the actual folder path
-output_file = "front_matter_report.txt"  # Replace with the desired output file path
-check_front_matter(folder_path, output_file)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Check markdown files for summary and keywords")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    output_file = "front_matter_report.txt"
+    check_front_matter(args.path, output_file)

--- a/extract_front_matter.py
+++ b/extract_front_matter.py
@@ -1,4 +1,5 @@
 import yaml
+import argparse
 
 def extract_and_print_front_matter(folder: str, file_name: str):
     """
@@ -31,6 +32,9 @@ def extract_and_print_front_matter(folder: str, file_name: str):
         print(f"An error occurred: {e}")
 
 # Example usage:
-folder = './_posts/'
-file_name = '2023-01-01-error_coefficientes.md'  # Replace with your file name
-extract_and_print_front_matter(folder, file_name)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Extract and print front matter from a markdown file")
+    parser.add_argument("--path", default="./_posts/", help="Folder containing the markdown file")
+    parser.add_argument("--file", default="2023-01-01-error_coefficientes.md", help="Markdown file name")
+    args = parser.parse_args()
+    extract_and_print_front_matter(args.path, args.file)

--- a/fix_date.py
+++ b/fix_date.py
@@ -1,6 +1,7 @@
 import os
 import re
 import frontmatter
+import argparse
 
 def extract_date_from_filename(filename):
     # Assuming the filename format is 'YYYY-MM-DD-some-title.md'
@@ -46,6 +47,8 @@ def process_markdown_files_in_directory(directory):
             filepath = os.path.join(directory, filename)
             process_markdown_file(filepath)
 
-# Example usage:
-directory_path = './_posts'  # Change to your directory path
-process_markdown_files_in_directory(directory_path)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fix dates in markdown front matter")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    process_markdown_files_in_directory(args.path)

--- a/fix_frontmatter.py
+++ b/fix_frontmatter.py
@@ -2,6 +2,7 @@ import os
 import re
 import frontmatter
 import random
+import argparse
 
 TOTAL_FILES = 20
 
@@ -93,6 +94,8 @@ def process_markdown_files_in_directory(directory):
             filepath = os.path.join(directory, filename)
             process_markdown_file(filepath)
 
-# Example usage:
-directory_path = './_posts'  # Change to your directory path
-process_markdown_files_in_directory(directory_path)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fix front matter in markdown files")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    process_markdown_files_in_directory(args.path)

--- a/markdown_category_checker.py
+++ b/markdown_category_checker.py
@@ -1,6 +1,7 @@
 import os
 import re
 import yaml
+import argparse
 from typing import List
 
 def read_markdown_files_from_folder(folder_path: str) -> List[str]:
@@ -41,7 +42,10 @@ def process_markdown_files(folder_path: str, output_txt_file: str):
             output_file.write(f'{filename}\n')
 
 
-folder_path = './_posts'  # Change this to your folder path
-output_txt_file = 'files_with_multiple_categories.txt'
-process_markdown_files(folder_path, output_txt_file)
-print(f'Processing complete. Files with multiple categories saved to {output_txt_file}')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Check categories in markdown files")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    output_txt_file = 'files_with_multiple_categories.txt'
+    process_markdown_files(args.path, output_txt_file)
+    print(f'Processing complete. Files with multiple categories saved to {output_txt_file}')

--- a/markdown_file_processor.py
+++ b/markdown_file_processor.py
@@ -1,6 +1,7 @@
 import os
 import re
 import string
+import argparse
 
 # List of stop words to remove from file names
 STOP_WORDS = {
@@ -122,6 +123,8 @@ def process_markdown_files_in_folder(folder_path: str):
             print(f"Finished processing file: {new_file_path}")
 
 
-# Path to the folder containing markdown files
-folder_path = "./_posts"
-process_markdown_files_in_folder(folder_path)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Process markdown files in a folder")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    process_markdown_files_in_folder(args.path)

--- a/markdown_frontmatter_cleanup.py
+++ b/markdown_frontmatter_cleanup.py
@@ -1,6 +1,7 @@
 import os
 import re
 import yaml
+import argparse
 from typing import List
 
 def read_markdown_files_from_folder(folder_path: str) -> List[str]:
@@ -81,6 +82,9 @@ def process_markdown_files(folder_path: str):
         except Exception as e:
             print(f"Error processing file {md_file}: {e}")
 
-folder_path = './_posts'  # Change this to your folder path
-process_markdown_files(folder_path)
-print(f"Processing complete.")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Clean up markdown front matter")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    process_markdown_files(args.path)
+    print("Processing complete.")

--- a/process_markdown_frontmatter.py
+++ b/process_markdown_frontmatter.py
@@ -1,6 +1,7 @@
 import os
 import re
 import yaml  # You might need to install PyYAML (pip install pyyaml)
+import argparse
 
 def process_frontmatter(frontmatter: dict):
     """
@@ -64,6 +65,8 @@ def process_folder(folder_path: str):
                 process_markdown_file(filepath)
 
 
-# Specify the folder path containing markdown files
-folder_path = './_posts'  # Replace with the actual folder path
-process_folder(folder_path)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Process markdown front matter")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    process_folder(args.path)

--- a/rename_files_spaces.py
+++ b/rename_files_spaces.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 
 
 def rename_files_in_folder(directory: str) -> None:
@@ -30,6 +31,7 @@ def rename_files_in_folder(directory: str) -> None:
 
 
 if __name__ == "__main__":
-    # You can change the path below to point to your folder
-    folder_path: str = './_posts'
-    rename_files_in_folder(folder_path)
+    parser = argparse.ArgumentParser(description="Rename files replacing spaces with underscores")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    rename_files_in_folder(args.path)

--- a/replace_latex.py
+++ b/replace_latex.py
@@ -1,5 +1,6 @@
 import os
 import re
+import argparse
 
 def replace_latex_syntax_in_file(file_path: str):
     """
@@ -47,5 +48,8 @@ def process_markdown_files_in_folder(folder_path: str):
             print(f'Finished processing file: {file_path}')
 
 
-folder_path = './_posts'
-process_markdown_files_in_folder(folder_path)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Replace LaTeX delimiters in markdown files")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    process_markdown_files_in_folder(args.path)

--- a/run_scripts.sh
+++ b/run_scripts.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-python markdown_file_processor.py  
-python fix_frontmatter.py 
-python search_code_snippets.py    
-# python process_markdown_frontmatter.py  
-python rename_files_spaces.py
-python markdown_frontmatter_cleanup.py
+TARGET="./_posts"
+
+python markdown_file_processor.py --path "$TARGET"
+python fix_frontmatter.py --path "$TARGET"
+python search_code_snippets.py --path "$TARGET"
+# python process_markdown_frontmatter.py --path "$TARGET"
+python rename_files_spaces.py --path "$TARGET"
+python markdown_frontmatter_cleanup.py --path "$TARGET"

--- a/search_code_snippets.py
+++ b/search_code_snippets.py
@@ -1,6 +1,7 @@
 import os
 import re
 import yaml
+import argparse
 
 # Function to extract front matter from markdown file
 def extract_front_matter(content: str):
@@ -99,6 +100,8 @@ def process_markdown_files(folder_path: str):
                 print(f"Updated front matter in {file}")
 
 
-# Example usage
-folder_path = './_posts'  # Update this path to your markdown folder
-process_markdown_files(folder_path)
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Search code snippets in markdown files")
+    parser.add_argument("--path", default="./_posts", help="Target folder")
+    args = parser.parse_args()
+    process_markdown_files(args.path)


### PR DESCRIPTION
## Summary
- add argparse with `--path` to all Python utilities
- default all utilities to `./_posts`
- update run_scripts.sh to pass a single target directory

## Testing
- `python -m py_compile *.py`
- `bash run_scripts.sh` *(fails: ModuleNotFoundError for missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6842ef07ba30832580cc881d225a561b