### PR TITLE
Improve article title styling

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -20,6 +20,15 @@ a:hover {
   color: #333333; // Dark gray
 }
 
+/* Override article title style */
+.page__title a {
+  color: $link-color;
+  font-weight: bold;
+}
+.page__title a:hover {
+  color: $link-color-hover;
+}
+
 
 /* Custom styles for the 404 page */
 .page__hero {


### PR DESCRIPTION
## Summary
- keep link color override for titles separate from other links
- highlight post titles with the site's link color and make them bold

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842ecc902b08325bb401e1a1823dafa