### PR TITLE
Add unit tests and workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,22 @@
+name: Python tests
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -v

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Serve the site locally with:
 bundle exec jekyll serve
 ```
 
+
+## Running tests
+
+Install the Python dependencies and execute:
+
+```bash
+pytest
+```
 GitHub Actions already runs these commands automatically during deployments.
 
 # ToDo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-frontmatter
 PyYAML
+pytest

--- a/tests/test_fix_date.py
+++ b/tests/test_fix_date.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+import frontmatter
+import pytest
+
+import fix_date
+
+
+def test_extract_date_from_filename():
+    assert fix_date.extract_date_from_filename('2023-12-01-post.md') == '2023-12-01'
+    assert fix_date.extract_date_from_filename('no-date.md') is None
+
+
+def create_markdown_file(path, front_matter):
+    content = frontmatter.dumps(front_matter) + "\nBody"
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+
+def load_front_matter(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return frontmatter.load(f)
+
+
+@pytest.mark.parametrize("initial_frontmatter, expected_date", [
+    ({'title': 'Test'}, '2024-02-03'),
+    ({'title': 'Test', 'date': '2020-01-01'}, '2024-02-03'),
+])
+def test_process_markdown_file_updates_date(tmp_path, initial_frontmatter, expected_date):
+    file_path = tmp_path / '2024-02-03-test.md'
+    create_markdown_file(file_path, initial_frontmatter)
+
+    fix_date.process_markdown_file(str(file_path))
+
+    updated = load_front_matter(file_path)
+    assert updated['date'] == expected_date


### PR DESCRIPTION
## Summary
- add pytest-based tests for `fix_date.py`
- add GitHub Actions workflow to run tests
- include pytest in requirements
- document how to run tests

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frontmatter')*

------
https://chatgpt.com/codex/tasks/task_e_6843070ea2788325bbb6571638a375f7