### PR TITLE
Switch to air skin and new fonts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@
 
 # theme                  : "minimal-mistakes-jekyll"
 remote_theme             : "mmistakes/minimal-mistakes@4.26.2"
-minimal_mistakes_skin    : "dark" #"dark"  "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
+minimal_mistakes_skin    : "air" #"dark"  "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Site Settings
 locale                   : "en"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,8 +20,7 @@
 <!-- Google Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Cardo&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;700&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
 
 {% if site.head_scripts %}
   {% for script in site.head_scripts %}

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -32,8 +32,8 @@ $calisto: "Calisto MT", serif !default;
 $garamond: Garamond, serif !default;
 
 // Setting the fonts
-$global-font-family: "Open Sans", Helvetica, Arial, sans-serif;
-$header-font-family: "Merriweather", "Times New Roman", serif;
+$global-font-family: "Roboto", Helvetica, Arial, sans-serif;
+$header-font-family: "Lora", "Times New Roman", serif;
 $caption-font-family: "Cardo, serif";
 
 /* type scale */


### PR DESCRIPTION
## Summary
- update Jekyll skin to `air`
- use new Google Fonts (Lora and Roboto)
- update font variables to match

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frontmatter')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-frontmatter)*

------
https://chatgpt.com/codex/tasks/task_e_68474f5f383c8325868e2c6c107d186a