### PR TITLE
Fix Sass skin compilation

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,6 +5,9 @@ search: false
 
 @charset "utf-8";
 
+// Import variables before skin so color variables are available
+@import "minimal-mistakes/variables";
+
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
 


### PR DESCRIPTION
## Summary
- ensure `assets/css/main.scss` imports theme variables before skins

## Testing
- `pytest -q`
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ef185d808325821a5d9d9951958f