### PR TITLE
Fix SCSS breakpoint placement

### DIFF
--- a/_sass/minimal-mistakes.scss
+++ b/_sass/minimal-mistakes.scss
@@ -9,7 +9,6 @@
 
 /* Mixins and functions */
 @forward "minimal-mistakes/vendor/breakpoint/breakpoint";
-@include breakpoint-set("to ems", true);
 @forward "minimal-mistakes/vendor/magnific-popup/magnific-popup";
 @forward "minimal-mistakes/vendor/susy/susy";
 @forward "minimal-mistakes/mixins";
@@ -38,3 +37,6 @@
 @forward "minimal-mistakes/archive";
 @forward "minimal-mistakes/sidebar";
 @forward "minimal-mistakes/print";
+
+// Configure Breakpoint after loading all modules
+@include breakpoint-set("to ems", true);


### PR DESCRIPTION
## Summary
- fix the ordering of `@forward` directives in `minimal-mistakes.scss`
- move the `breakpoint-set` mixin call after all forwards to avoid compilation errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f318bed88325856491c8153ed76c