### PR TITLE
Fix SCSS variable import path

### DIFF
--- a/_sass/minimal-mistakes/vendor/magnific-popup/_settings.scss
+++ b/_sass/minimal-mistakes/vendor/magnific-popup/_settings.scss
@@ -1,5 +1,5 @@
 @use 'sass:math';
-@use "../../variables" as *;
+@use "minimal-mistakes/variables" as *;
 ////////////////////////
 //      Settings      //
 ////////////////////////


### PR DESCRIPTION
## Summary
- fix SCSS path so vendor popup styles can access theme variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853cd022f608325a16ce39dd9ef0334