### PR TITLE
Fix Sass variable scope for reset

### DIFF
--- a/_sass/minimal-mistakes/_reset.scss
+++ b/_sass/minimal-mistakes/_reset.scss
@@ -2,6 +2,8 @@
    STYLE RESETS
    ========================================================================== */
 
+@use "variables" as *;
+
 * { box-sizing: border-box; }
 
 html {


### PR DESCRIPTION
## Summary
- ensure `_sass/minimal-mistakes/_reset.scss` has access to theme variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853d96991608325a0a79b160233e669