### PR TITLE
Fix SCSS mixin import

### DIFF
--- a/_sass/minimal-mistakes/_buttons.scss
+++ b/_sass/minimal-mistakes/_buttons.scss
@@ -1,5 +1,6 @@
 @use "sass:color";
 @use "variables" as *;
+@use "mixins" as *; // Import mixins for color contrast helpers
 /* ==========================================================================
    BUTTONS
    ========================================================================== */


### PR DESCRIPTION
## Summary
- fix the missing `mixins` import for buttons

## Testing
- `pytest -q`
- `bundle exec jekyll build` *(fails: bundler or jekyll not available)*

------
https://chatgpt.com/codex/tasks/task_e_6853de9c6764832594883fb4a9c7b9b4