### PR TITLE
Fix SCSS breakpoint mixin import

### DIFF
--- a/_sass/minimal-mistakes/_utilities.scss
+++ b/_sass/minimal-mistakes/_utilities.scss
@@ -1,5 +1,7 @@
 @use "sass:color";
 @use "variables" as *;
+@use "mixins" as *;
+@use "vendor/breakpoint/breakpoint" as *;
 /* ==========================================================================
    UTILITY CLASSES
    ========================================================================== */


### PR DESCRIPTION
## Summary
- add missing mixin imports so Minimal Mistakes utilities compile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853df8b6dfc8325a4e2959bbb1cb844