### PR TITLE
Fix SCSS span negative operation

### DIFF
--- a/_sass/minimal-mistakes/_utilities.scss
+++ b/_sass/minimal-mistakes/_utilities.scss
@@ -186,7 +186,9 @@ body:hover .visually-hidden button {
 
 .full {
   @include breakpoint($large) {
-    margin-right: -1 * span(2.5 of 12) !important;
+    // `span()` returns a `calc()` expression which cannot be multiplied.
+    // Passing a negative value directly avoids the undefined operation error.
+    margin-right: span(-2.5 of 12) !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- fix `span` usage in `_utilities.scss` to avoid undefined operation error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e1781ea8832585cc2baf38ca5c90