### PR TITLE
Fix undefined SCSS mixin

### DIFF
--- a/_sass/minimal-mistakes.scss
+++ b/_sass/minimal-mistakes.scss
@@ -9,6 +9,7 @@
 
 /* Mixins and functions */
 @forward "minimal-mistakes/vendor/breakpoint/breakpoint";
+@use "minimal-mistakes/vendor/breakpoint/breakpoint" as breakpoint;
 @forward "minimal-mistakes/vendor/magnific-popup/magnific-popup";
 @forward "minimal-mistakes/vendor/susy/susy";
 @forward "minimal-mistakes/mixins";
@@ -39,4 +40,4 @@
 @forward "minimal-mistakes/print";
 
 // Configure Breakpoint after loading all modules
-@include breakpoint-set("to ems", true);
+@include breakpoint.breakpoint-set("to ems", true);


### PR DESCRIPTION
## Summary
- import the breakpoint mixins and call them with proper namespace

## Testing
- `pytest -q`
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6853e337cf40832583d3a0a0c94e0b4e