### PR TITLE
Fix Jekyll build by loading mixins in Sass

### DIFF
--- a/_sass/minimal-mistakes/_base.scss
+++ b/_sass/minimal-mistakes/_base.scss
@@ -4,6 +4,7 @@
 
 @use "variables" as *;
 @use "vendor/breakpoint/breakpoint" as *;
+@use "mixins";
 
 html {
   /* sticky footer fix */

--- a/_sass/minimal-mistakes/_reset.scss
+++ b/_sass/minimal-mistakes/_reset.scss
@@ -4,6 +4,7 @@
 
 @use "variables" as *;
 @use "vendor/breakpoint/breakpoint" as *;
+@use "mixins";
 
 * { box-sizing: border-box; }
 


### PR DESCRIPTION
## Summary
- import mixins in `_base.scss`
- import mixins in `_reset.scss`

## Testing
- `npm run lint:css` *(fails: stylelint not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e3f80b848325aac7c5bddfa7f7ca