### PR TITLE
Add package docs page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -20,3 +20,5 @@ main:
   #   url: /sitemap/
   - title: "Code Download"
     url: /code/
+  - title: "Package Docs"
+    url: /docs/

--- a/_pages/package-docs.md
+++ b/_pages/package-docs.md
@@ -1,0 +1,16 @@
+---
+layout: single
+title: "Package Documentation"
+permalink: /docs/
+author_profile: true
+---
+
+This page collects links to documentation for the packages I maintain. When available, documentation is hosted online. Otherwise it will be stored directly in this repository.
+
+## Packages
+
+- [**frontmatter**]({{ '/docs/frontmatter/' | relative_url }})
+
+---
+
+Feel free to reach out at [dfr@esmad.ipp.pt](mailto:dfr@esmad.ipp.pt) for professional enquiries or [diogo.debastos.ribeiro@gmail.com](mailto:diogo.debastos.ribeiro@gmail.com) for personal matters. My ORCID is [0009-0001-2022-7072](https://orcid.org/0009-0001-2022-7072) and I’m affiliated with **ESMAD - Instituto Politécnico do Porto**.

--- a/docs/frontmatter/index.md
+++ b/docs/frontmatter/index.md
@@ -1,0 +1,8 @@
+---
+layout: single
+title: "frontmatter package"
+parent: Package Documentation
+nav_order: 1
+---
+
+Detailed documentation for the **frontmatter** Python package will be provided here.


### PR DESCRIPTION
## Summary
- create a `Package Documentation` page
- link the page from the navigation menu
- stub documentation for the `frontmatter` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557053e6dc832589d800ba5d225f40