### PR TITLE
Consolidate taxonomy: 1471 tags to 71, 156 categories to 12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :jekyll_plugins do
     # gem "webrick" # Add this line
     gem "jekyll-seo-tag"
     gem "jekyll-sitemap"
+    gem "jekyll-redirect-from"		# keeps pre-consolidation category URLs alive
     gem 'jekyll-include-cache'			# gem to speed up Liquid parsing
     gem 'jekyll-commonmark'			    # gem to speed up Markdown
     gem 'liquid-md5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-remote-theme (0.5.2)
       addressable (~> 2.0)
       jekyll (>= 3.5, < 5.0)
@@ -235,6 +237,7 @@ DEPENDENCIES
   jekyll-archives
   jekyll-commonmark
   jekyll-include-cache
+  jekyll-redirect-from
   jekyll-remote-theme
   jekyll-seo-tag
   jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -246,6 +246,7 @@ plugins:
   - jekyll-feed
   - jekyll-include-cache
   - jekyll-seo-tag
+  - jekyll-redirect-from
 
 # mimic GitHub Pages with --safe
 whitelist:
@@ -255,6 +256,7 @@ whitelist:
   - jekyll-feed
   - jekyll-include-cache
   - jekyll-seo-tag
+  - jekyll-redirect-from
 
 
 # Archives

--- a/_posts/2020-01-08-heteroscedascity_statistical_tests.md
+++ b/_posts/2020-01-08-heteroscedascity_statistical_tests.md
@@ -26,9 +26,8 @@ seo_type: article
 summary: Explore heteroscedasticity in regression analysis, its consequences, how
   to test for it, and practical solutions for correcting it when detected.
 tags:
-- Regression analysis
-- Econometrics
-- Heteroscedasticity
+- Regression
+- Economics
 title: 'Heteroscedasticity: Statistical Tests and Solutions'
 ---
 

--- a/_posts/2020-01-09-chisquare_test_exploring_categorical_data_goodnessoffit.md
+++ b/_posts/2020-01-09-chisquare_test_exploring_categorical_data_goodnessoffit.md
@@ -30,10 +30,8 @@ summary: Learn about the Chi-Square test for categorical data analysis, includin
   its use in goodness-of-fit and independence tests, and how it's applied in fields
   such as survey data analysis and genetics.
 tags:
-- Chi-square test
-- Categorical data
-- Goodness-of-fit
-- Statistical testing
+- Hypothesis Testing
+- Data Analysis
 - Python
 title: 'Chi-Square Test: Exploring Categorical Data and Goodness-of-Fit'
 ---

--- a/_posts/2020-01-10-critical_considerations_before_using_boxcox_transformation_hypothesis_testing.md
+++ b/_posts/2020-01-10-critical_considerations_before_using_boxcox_transformation_hypothesis_testing.md
@@ -28,10 +28,10 @@ summary: This article outlines key considerations when using the Box-Cox transfo
   including its purpose, effects on hypothesis testing, interpretation challenges,
   alternatives, and how to handle missing data, outliers, and model assumptions.
 tags:
-- Box-cox transformation
-- Hypothesis testing
-- Statistical modeling
-- Data transformation
+- Regression
+- Hypothesis Testing
+- Statistical Modeling
+- Feature Engineering
 title: Critical Considerations Before Using the Box-Cox Transformation for Hypothesis
   Testing
 ---

--- a/_posts/2020-01-11-logrank_test_comparing_survival_curves_clinical_studies.md
+++ b/_posts/2020-01-11-logrank_test_comparing_survival_curves_clinical_studies.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Medical Research
 classes: wide
 date: '2020-01-11'
 excerpt: The Log-Rank test is a vital statistical method used to compare survival
@@ -22,6 +21,8 @@ keywords:
 - Survival analysis
 - Medical statistics
 - Epidemiology
+redirect_from:
+- '/statistics/medical research/logrank_test_comparing_survival_curves_clinical_studies/'
 seo_description: A comprehensive guide to the Log-Rank test, a statistical tool for
   comparing survival distributions in clinical trials and medical research.
 seo_title: 'Log-Rank Test: Comparing Survival Curves'
@@ -30,10 +31,9 @@ summary: Discover how the Log-Rank test is used to compare survival curves in cl
   studies, with detailed insights into its applications in clinical trials, epidemiology,
   and medical research.
 tags:
-- Log-rank test
-- Survival analysis
-- Clinical trials
-- Medical research
+- Survival Analysis
+- Experimental Design
+- Healthcare
 - Epidemiology
 title: 'Log-Rank Test: Comparing Survival Curves in Clinical Studies'
 ---

--- a/_posts/2020-01-12-applications_time_series_analysis_epidemiological_research.md
+++ b/_posts/2020-01-12-applications_time_series_analysis_epidemiological_research.md
@@ -28,11 +28,9 @@ summary: Explore how time series analysis is used in epidemiological research to
   disease transmission, detect outbreaks, and predict future cases. This article covers
   techniques like ARIMA, moving averages, and their applications in public health.
 tags:
-- Time series analysis
+- Time Series
 - Epidemiology
-- Disease modeling
-- Outbreak detection
-- Predictive analytics
+- Machine Learning
 title: Applications of Time Series Analysis in Epidemiological Research
 ---
 

--- a/_posts/2020-01-13-rethinking_statistical_test_selection_why_diagrams_failing_us.md
+++ b/_posts/2020-01-13-rethinking_statistical_test_selection_why_diagrams_failing_us.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Statistics
 classes: wide
 date: '2020-01-13'
 excerpt: Most diagrams for choosing statistical tests miss the bigger picture. Here's a bold, practical approach that emphasizes interpretation over mechanistic rules, and cuts through statistical misconceptions like the N>30 rule.
@@ -19,15 +18,16 @@ keywords:
 - Data Science
 - Hypothesis Testing
 - Nonparametric Tests
+redirect_from:
+- '/data science/statistics/rethinking_statistical_test_selection_why_diagrams_failing_us/'
 seo_description: 'A critical take on statistical test selection: move past decision diagrams and N>30 pseudorules toward meaningful interpretation and robust testing.'
 seo_title: Rethinking How We Choose Statistical Tests
 seo_type: article
 summary: This article critiques popular frameworks for selecting statistical tests, offering a robust, more flexible alternative that emphasizes interpretation and realistic outcomes over pseudorules and data transformations. Learn why techniques like Welch’s t-test and permutation tests are better than many 'classics'.
 tags:
-- Statistical Analysis
+- Statistical Modeling
 - Data Science
-- Testing Frameworks
-- Welch Test
+- Hypothesis Testing
 title: 'Rethinking Statistical Test Selection: Why the Diagrams Are Failing Us'
 ---
 

--- a/_posts/2020-01-14-real_issues_residual_diagnostics_model_fitting.md
+++ b/_posts/2020-01-14-real_issues_residual_diagnostics_model_fitting.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Statistics
 classes: wide
 date: '2020-01-14'
 excerpt: Residual diagnostics often trigger debates, especially when tests like Shapiro-Wilk
@@ -22,6 +21,8 @@ keywords:
 - Generalized least squares
 - Mixed models
 - Statistical modeling
+redirect_from:
+- '/data science/statistics/real_issues_residual_diagnostics_model_fitting/'
 seo_description: Why Shapiro-Wilk falls short in residual diagnostics, and what to check instead when fitting models to longitudinal data with GLS and robust alternatives.
 seo_title: Residual Diagnostics Beyond Shapiro-Wilk
 seo_type: article
@@ -31,10 +32,8 @@ summary: In this article, we examine why the Shapiro-Wilk test should not be the
   role of kurtosis, skewness, and the practical impact of non-normality on parameter
   estimates.
 tags:
-- Residual analysis
-- Longitudinal data
-- Generalized least squares
-- Parametric models
+- Regression
+- Survival Analysis
 title: 'Don''t Get MAD About Shapiro-Wilk: Real Issues in Residual Diagnostics and
   Model Fitting'
 ---

--- a/_posts/2020-01-30-cox_proportional_hazards_model.md
+++ b/_posts/2020-01-30-cox_proportional_hazards_model.md
@@ -31,12 +31,9 @@ seo_type: article
 summary: A comprehensive guide to the Cox Proportional Hazards Model, its assumptions,
   and applications in survival analysis and clinical trials.
 tags:
-- Cox proportional hazards model
-- Survival analysis
-- Medical studies
-- Clinical trials
-- Time-to-event data
-- Censored data
+- Survival Analysis
+- Healthcare
+- Experimental Design
 - R
 - Python
 title: 'Cox Proportional Hazards Model: A Guide to Survival Analysis in Medical Studies'

--- a/_posts/2020-02-01-anova_kruskal_walis.md
+++ b/_posts/2020-02-01-anova_kruskal_walis.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Analysis
-- Hypothesis Testing
 classes: wide
 date: '2020-02-01'
 excerpt: Learn the key differences between ANOVA and Kruskal-Wallis tests, and understand
@@ -21,6 +19,8 @@ keywords:
 - Anova
 - Non-parametric test
 - Hypothesis testing
+redirect_from:
+- '/statistics/data analysis/hypothesis testing/anova_kruskal_walis/'
 seo_description: The differences between ANOVA and Kruskal-Wallis, and when to choose parametric or non-parametric methods for comparing multiple groups.
 seo_title: 'ANOVA vs Kruskal-Wallis: When to Use Each'
 seo_type: article
@@ -28,11 +28,9 @@ summary: This article explores the fundamental differences between ANOVA and Kru
   tests, with a focus on their assumptions, applications, and when to use each method
   in data analysis.
 tags:
-- Kruskal-wallis
-- Non-parametric methods
-- Anova
+- Hypothesis Testing
+- Nonparametric Methods
 - Statistics
-- Hypothesis testing
 title: 'ANOVA vs Kruskal-Wallis: Understanding the Differences and Applications'
 ---
 

--- a/_posts/2020-02-02-understanding_statistical_testing_null_hypothesis_beyond.md
+++ b/_posts/2020-02-02-understanding_statistical_testing_null_hypothesis_beyond.md
@@ -26,9 +26,8 @@ summary: This article delves into the core principles of hypothesis testing, the
   of the null hypothesis, and the various statistical tools used to test data compatibility
   with theoretical distributions.
 tags:
-- Hypothesis testing
-- Null hypothesis
-- Statistical methods
+- Hypothesis Testing
+- Statistical Modeling
 title: 'Understanding Statistical Testing: The Null Hypothesis and Beyond'
 ---
 

--- a/_posts/2020-02-17-arimax_time_series.md
+++ b/_posts/2020-02-17-arimax_time_series.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time Series Analysis
+- Time Series
 classes: wide
 date: '2020-02-17'
 excerpt: The ARIMAX model extends ARIMA by integrating exogenous variables into time
@@ -20,6 +20,8 @@ keywords:
 - Forecasting
 - Time series
 - Arimax
+redirect_from:
+- '/time series analysis/arimax_time_series/'
 seo_description: The ARIMAX model for time series forecasting with exogenous variables, and how it builds on ARIMA to improve predictive performance.
 seo_title: 'ARIMAX Time Series Model: An In-Depth Guide'
 seo_type: article
@@ -28,11 +30,9 @@ summary: This article explores the ARIMAX time series model, which enhances ARIM
   applications, and how it compares to ARIMA.
 tags:
 - R
-- Statistical modeling
-- Machine learning
-- Arima
-- Time series forecasting
-- Arimax
+- Statistical Modeling
+- Machine Learning
+- Time Series
 title: 'ARIMAX Time Series: Comprehensive Guide'
 ---
 

--- a/_posts/2020-03-01-type_one_type_two_erros.md
+++ b/_posts/2020-03-01-type_one_type_two_erros.md
@@ -27,11 +27,8 @@ summary: This article provides an in-depth exploration of Type I and Type II err
   in hypothesis testing, explaining their importance, the trade-offs between them,
   and how they impact decisions in various domains, from clinical trials to business.
 tags:
-- Type ii error
-- False positive
-- False negative
-- Hypothesis testing
-- Type i error
+- Hypothesis Testing
+- Model Evaluation
 title: Understanding Type I and Type II Errors in Hypothesis Testing
 ---
 

--- a/_posts/2020-03-29-realtime_data_processing_epidemiological_surveillance.md
+++ b/_posts/2020-03-29-realtime_data_processing_epidemiological_surveillance.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Epidemiology
 classes: wide
 date: '2020-03-29'
 excerpt: Real-time data processing platforms like Apache Flink are revolutionizing
@@ -22,6 +21,8 @@ keywords:
 - Disease tracking
 - Real-time analytics
 - Public health data
+redirect_from:
+- '/data science/epidemiology/realtime_data_processing_epidemiological_surveillance/'
 seo_description: How real-time platforms like Apache Flink improve epidemiological surveillance, enabling accurate and timely disease tracking and outbreak detection.
 seo_title: Real-Time Epidemiological Surveillance with Flink
 seo_type: article
@@ -30,11 +31,8 @@ summary: Explore how real-time data processing platforms like Apache Flink are u
   detection, and informed public health decisions. Learn about the benefits and challenges
   of implementing real-time analytics in disease monitoring systems.
 tags:
-- Real-time data processing
-- Apache flink
-- Epidemiological surveillance
-- Disease tracking
-- Public health analytics
+- Data Engineering
+- Epidemiology
 title: Real-Time Data Processing and Epidemiological Surveillance
 ---
 

--- a/_posts/2020-03-30-sustainability_analytics_how_data_science_drives_green_innovation.md
+++ b/_posts/2020-03-30-sustainability_analytics_how_data_science_drives_green_innovation.md
@@ -26,11 +26,9 @@ summary: In this article, we explore the role of data science in driving green i
   through sustainability analytics, examining how companies use data to optimize resources,
   cut waste, and enhance supply chain efficiency.
 tags:
-- Sustainability analytics
-- Data science
-- Green innovation
-- Resource optimization
-- Supply chain efficiency
+- Data Science
+- Optimization
+- Supply Chain
 title: 'Sustainability Analytics: How Data Science Drives Green Innovation'
 ---
 

--- a/_posts/2020-04-01-friedman_test.md
+++ b/_posts/2020-04-01-friedman_test.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Data Analysis
+- Data Science
 classes: wide
 date: '2020-04-01'
 excerpt: The Friedman test is a non-parametric alternative to repeated measures ANOVA,
@@ -19,6 +19,8 @@ keywords:
 - Non-parametric test
 - Friedman test
 - Ordinal data
+redirect_from:
+- '/data analysis/friedman_test/'
 seo_description: The Friedman test as a non-parametric alternative to repeated measures ANOVA, and its use with ordinal data or non-normal distributions.
 seo_title: 'Friedman Test: Non-Parametric Repeated Measures'
 seo_type: article
@@ -26,10 +28,9 @@ summary: This article provides an in-depth explanation of the Friedman test, inc
   its use as a non-parametric alternative to repeated measures ANOVA, when to use
   it, and practical examples in ranking data and repeated measurements.
 tags:
-- Non-parametric tests
-- Repeated measures anova
-- Friedman test
-- Ordinal data
+- Nonparametric Methods
+- Hypothesis Testing
+- Regression
 title: 'The Friedman Test: Non-Parametric Alternative to Repeated Measures ANOVA'
 ---
 

--- a/_posts/2020-04-27-prediction_errors_bias_variance_model.md
+++ b/_posts/2020-04-27-prediction_errors_bias_variance_model.md
@@ -23,12 +23,9 @@ summary: This article explores methods for estimating prediction error, includin
   cross-validation, bootstrap techniques, and their variations like the .632 estimator,
   focusing on balancing bias, variance, and model evaluation accuracy.
 tags:
-- Bias-variance tradeoff
-- Model evaluation
-- .632 estimator
-- Cross-validation
-- Bootstrap methods
-- Prediction error
+- Descriptive Statistics
+- Model Evaluation
+- Monte Carlo
 - Python
 title: 'Understanding Prediction Error: Bias, Variance, and Model Evaluation Techniques'
 ---

--- a/_posts/2020-05-01-shapiro_wilk_test.md
+++ b/_posts/2020-05-01-shapiro_wilk_test.md
@@ -23,11 +23,9 @@ seo_title: Shapiro-Wilk vs. Anderson-Darling Normality Tests
 seo_type: article
 summary: This article explores two common normality tests—the Shapiro-Wilk test and the Anderson-Darling test—discussing their differences, when to use each, and how to interpret their results to determine the appropriate statistical method.
 tags:
-- Anderson-darling test
-- Normality tests
-- Non-parametric methods
-- Shapiro-wilk test
-- Parametric methods
+- Hypothesis Testing
+- Nonparametric Methods
+- Statistical Modeling
 title: 'Shapiro-Wilk Test vs. Anderson-Darling Test: Checking Normality in Data'
 ---
 

--- a/_posts/2020-05-26-false_positive_rate.md
+++ b/_posts/2020-05-26-false_positive_rate.md
@@ -30,10 +30,8 @@ summary: This article provides a detailed examination of the False Positive Rate
   it plays a crucial role.
 tags:
 - R
-- False positive rate
-- Model evaluation
-- Machine learning metrics
-- Binary classification
+- Model Evaluation
+- Classification
 title: Analysis of the False Positive Rate (FPR) in Machine Learning
 ---
 

--- a/_posts/2020-06-01-ordinary_least_square_regression.md
+++ b/_posts/2020-06-01-ordinary_least_square_regression.md
@@ -29,11 +29,9 @@ summary: This article covers Ordinary Least Squares (OLS) regression, one of the
   about its key properties, how it works, and its wide range of applications in modeling
   linear relationships between variables.
 tags:
-- Homoscedasticity
-- Ols regression
-- Linear regression
-- Gauss-markov theorem
-- Maximum likelihood estimator
+- Regression
+- Stochastic Processes
+- Probability
 title: 'Ordinary Least Squares (OLS) Regression: Properties and Applications'
 ---
 

--- a/_posts/2020-06-10-arima_time_series.md
+++ b/_posts/2020-06-10-arima_time_series.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time Series Analysis
+- Time Series
 classes: wide
 date: '2020-06-10'
 excerpt: Learn the fundamentals of ARIMA modeling for time series analysis. This guide
@@ -22,6 +22,8 @@ keywords:
 - Sarima
 - R
 - Arma
+redirect_from:
+- '/time series analysis/arima_time_series/'
 seo_description: 'The ARIMA model explained: components, parameter identification, validation, and applications, with comparisons to ARIMAX, SARIMA, and ARMA.'
 seo_title: 'Comprehensive ARIMA Model Guide: Time Series Analysis'
 seo_type: article
@@ -29,8 +31,7 @@ summary: This guide provides an in-depth exploration of ARIMA modeling for time 
   data, discussing its core components, parameter estimation, validation, and comparison
   with models like ARIMAX, SARIMA, and ARMA.
 tags:
-- Arima
-- Time series
+- Time Series
 - Forecasting
 - R
 - Python

--- a/_posts/2020-07-01-cocharan_q_test.md
+++ b/_posts/2020-07-01-cocharan_q_test.md
@@ -24,10 +24,8 @@ seo_title: 'Cochran’s Q Test: Comparing Proportions in Related Groups'
 seo_type: article
 summary: This article explores Cochran’s Q test, a non-parametric method for comparing proportions in related groups, particularly in binary data. It also covers the relationship between Cochran's Q, McNemar's test, and logistic regression.
 tags:
-- Logistic regression
-- Mcnemar's test
-- Non-parametric tests
-- Cochran's q test
+- Regression
+- Nonparametric Methods
 title: 'Cochran’s Q Test: Comparing Three or More Related Proportions'
 ---
 

--- a/_posts/2020-07-02-mannwhitney_u_test_vs_independent_t_test_non_parametric_alternatives.md
+++ b/_posts/2020-07-02-mannwhitney_u_test_vs_independent_t_test_non_parametric_alternatives.md
@@ -28,11 +28,8 @@ summary: This article provides a comprehensive comparison between the Mann-Whitn
   U test is preferred over the parametric t-test, especially in the case of non-normal
   distributions, and provides practical examples of both tests.
 tags:
-- Mann-whitney u test
-- Independent t-test
-- Non-parametric tests
-- Parametric tests
-- Hypothesis testing
+- Hypothesis Testing
+- Nonparametric Methods
 title: 'Mann-Whitney U Test vs. Independent T-Test: Non-Parametric Alternatives'
 ---
 

--- a/_posts/2020-07-26-measurement_errors.md
+++ b/_posts/2020-07-26-measurement_errors.md
@@ -20,16 +20,10 @@ summary: A comprehensive guide to understanding observational and measurement er
   covering random and systematic errors, their statistical models, and methods to
   estimate and mitigate their effects.
 tags:
-- Statistical bias
-- Statistical methods
-- Uncertainty
-- Data quality
-- Precision
-- Calibration
-- Random errors
-- Systematic errors
-- Accuracy
-- Measurement error
+- Statistical Modeling
+- Confidence Intervals
+- Data Quality
+- Model Evaluation
 title: 'Understanding Observational Error: Detailed Insights and Implications'
 ---
 

--- a/_posts/2020-08-01-understanding_markov_chain_monte_carlo.md
+++ b/_posts/2020-08-01-understanding_markov_chain_monte_carlo.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Algorithms
+- Mathematics
 classes: wide
 date: '2020-08-01'
 excerpt: This article delves into the fundamentals of Markov Chain Monte Carlo (MCMC),
@@ -22,6 +22,8 @@ keywords:
 - Python
 - Bayesian inference
 - Bash
+redirect_from:
+- '/algorithms/understanding_markov_chain_monte_carlo/'
 seo_description: 'Markov Chain Monte Carlo (MCMC) explained: its algorithms and applications in statistics, probability theory, and numerical approximation.'
 seo_title: Comprehensive Guide to Markov Chain Monte Carlo (MCMC)
 seo_type: article
@@ -30,12 +32,12 @@ summary: Markov Chain Monte Carlo (MCMC) is an essential tool in probabilistic c
   algorithms like Metropolis-Hastings, and various applications in statistics and
   numerical integration.
 tags:
-- Markov chain monte carlo
-- Probability distributions
+- Stochastic Processes
+- Probability
 - Python
-- Bash
-- Bayesian statistics
-- Numerical methods
+- Programming
+- Bayesian Statistics
+- Numerical Methods
 title: Understanding Markov Chain Monte Carlo (MCMC)
 ---
 

--- a/_posts/2020-09-01-threshold_classification_zero_inflated_time_series.md
+++ b/_posts/2020-09-01-threshold_classification_zero_inflated_time_series.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time Series Analysis
+- Time Series
 classes: wide
 date: '2020-09-01'
 excerpt: This article explores the use of stationary distributions in time series
@@ -18,6 +18,8 @@ keywords:
 - Zero-inflated data
 - Threshold classification
 - Statistical modeling
+redirect_from:
+- '/time series analysis/threshold_classification_zero_inflated_time_series/'
 seo_description: A method for threshold classification in zero-inflated time series using stationary distributions and parametric modeling.
 seo_title: Threshold Classification for Zero-Inflated Series
 seo_type: article
@@ -26,10 +28,9 @@ summary: A novel approach for threshold classification in zero-inflated time ser
   addresses the limitations of traditional techniques by leveraging parametric distribution
   quantiles for better accuracy and generalization.
 tags:
-- Statistical modeling
-- Zero-inflated data
-- Stationary distribution
-- Time series
+- Statistical Modeling
+- Probability
+- Time Series
 title: A Generalized Approach to Threshold Classification for Zero-Inflated Time Series
   Data Using Stationary Distributions
 ---

--- a/_posts/2020-09-02-log_rank_test_survival_analysis_comparing_survival_curves.md
+++ b/_posts/2020-09-02-log_rank_test_survival_analysis_comparing_survival_curves.md
@@ -28,11 +28,9 @@ summary: This article provides a comprehensive guide to the log-rank test in sur
   two or more groups. We explain how to interpret Kaplan-Meier curves, p-values from
   the log-rank test, and real-world applications in clinical trials.
 tags:
-- Log-rank test
-- Survival analysis
-- Medical statistics
-- Kaplan-meier curves
-- P-values
+- Survival Analysis
+- Statistical Modeling
+- Hypothesis Testing
 title: 'Log-Rank Test in Survival Analysis: Comparing Survival Curves'
 ---
 

--- a/_posts/2020-09-24-demand_forecast_supply_chain.md
+++ b/_posts/2020-09-24-demand_forecast_supply_chain.md
@@ -28,10 +28,8 @@ summary: This article explores the use of customer behavior modeling to improve 
   the Lifetimes Python library are used to predict repurchases and optimize sales
   predictions over a future period.
 tags:
-- Customer behavior
+- Customer Analytics
 - Python
-- Demand forecasting
-- Repurchase models
 title: A Predictive Approach for Demand Forecasting in the Supply Chain Using Customer
   Behavior Modeling
 ---

--- a/_posts/2020-10-01-time_series_models_predicting_emergency.md
+++ b/_posts/2020-10-01-time_series_models_predicting_emergency.md
@@ -26,11 +26,9 @@ summary: A study comparing machine learning models (random forest, GBM) with uni
   time series models (ARIMA, ETS, Prophet) for predicting emergency department visits.
   Results show machine learning models perform better, though not substantially so.
 tags:
-- Emergency department
-- Time series forecasting
-- Machine learning
-- Gradient boosted machines
-- Random forest
+- Time Series
+- Machine Learning
+- Decision Trees
 title: Machine Learning vs. Univariate Time Series Models in Predicting Emergency
   Department Visit Volumes
 ---

--- a/_posts/2020-11-05-probability_theory_basics.md
+++ b/_posts/2020-11-05-probability_theory_basics.md
@@ -27,7 +27,7 @@ summary: This post reviews essential probability concepts like random variables,
 tags:
 - Probability
 - Statistics
-- Data science
+- Data Science
 title: Probability Theory Basics for Data Science
 ---
 

--- a/_posts/2020-11-10-simple_linear_regression_intro.md
+++ b/_posts/2020-11-10-simple_linear_regression_intro.md
@@ -26,7 +26,7 @@ summary: This article introduces simple linear regression and the least squares 
 tags:
 - Regression
 - Statistics
-- Data science
+- Data Science
 title: A Primer on Simple Linear Regression
 ---
 

--- a/_posts/2020-11-20-bayesian_inference_basics.md
+++ b/_posts/2020-11-20-bayesian_inference_basics.md
@@ -25,8 +25,8 @@ seo_type: article
 summary: Learn how Bayesian inference updates prior beliefs into posterior distributions,
   providing a flexible framework for reasoning under uncertainty.
 tags:
-- Bayesian
-- Inference
+- Bayesian Statistics
+- Statistical Modeling
 - Statistics
 title: Bayesian Inference Explained
 ---

--- a/_posts/2020-11-25-hypothesis_testing_real_world_applications.md
+++ b/_posts/2020-11-25-hypothesis_testing_real_world_applications.md
@@ -26,9 +26,9 @@ summary: This post walks through frequentist hypothesis testing, showing how to 
   null and alternative hypotheses and interpret the results in practical data science
   tasks.
 tags:
-- Hypothesis testing
+- Hypothesis Testing
 - Statistics
-- Experiments
+- Experimental Design
 title: Applying Hypothesis Testing in the Real World
 ---
 

--- a/_posts/2020-11-30-data_visualization_best_practices.md
+++ b/_posts/2020-11-30-data_visualization_best_practices.md
@@ -25,9 +25,9 @@ seo_type: article
 summary: Learn how to design effective visualizations by focusing on clarity, appropriate
   chart selection, and thoughtful use of color and labels.
 tags:
-- Visualization
-- Data science
-- Communication
+- Data Visualization
+- Data Science
+- Research Methodology
 title: Data Visualization Best Practices
 ---
 

--- a/_posts/2020-12-01-predictive_maintenance_data_science.md
+++ b/_posts/2020-12-01-predictive_maintenance_data_science.md
@@ -28,10 +28,9 @@ summary: This article delves into the role of data science in predictive mainten
   (PdM), explaining how methods such as regression, anomaly detection, and clustering
   help forecast equipment failures, reduce downtime, and optimize maintenance strategies.
 tags:
-- Data science
-- Machine learning
-- Predictive maintenance
-- Industrial applications
+- Data Science
+- Machine Learning
+- Predictive Maintenance
 title: The Role of Data Science in Predictive Maintenance
 ---
 

--- a/_posts/2020-12-30-ordinal_regression.md
+++ b/_posts/2020-12-30-ordinal_regression.md
@@ -27,10 +27,9 @@ summary: This article explains ordinal regression models, from their mathematica
   structure to real-world applications, including how marginal effects make model
   outputs more interpretable in Python.
 tags:
-- Statistical models
-- Data analysis
-- Ordinal regression
-- Marginal effects
+- Statistical Modeling
+- Data Analysis
+- Regression
 - Python
 title: 'Understanding Ordinal Regression: A Comprehensive Guide'
 ---

--- a/_posts/2021-01-01-pde_data_science.md
+++ b/_posts/2021-01-01-pde_data_science.md
@@ -29,10 +29,8 @@ summary: This article explores the role of Partial Differential Equations (PDEs)
   and environmental modeling. It covers basic classifications of PDEs, solution methods,
   and why data scientists should care about them.
 tags:
-- Physics-informed models
-- Machine learning
-- Pdes
-- Numerical methods
+- Machine Learning
+- Numerical Methods
 title: Introduction to Partial Differential Equations (PDEs) from a Data Science Perspective
 ---
 

--- a/_posts/2021-02-01-bayesian.md
+++ b/_posts/2021-02-01-bayesian.md
@@ -29,10 +29,9 @@ summary: Bayesian data science is a statistical approach that incorporates prior
   framework for modeling uncertainty and improving decision-making, especially in
   complex or small data scenarios.
 tags:
-- Inference
-- Statistical modeling
-- Data science
-- Bayesian statistics
+- Statistical Modeling
+- Data Science
+- Bayesian Statistics
 - Probability
 title: 'Bayesian Data Science: The What, Why, and How'
 ---

--- a/_posts/2021-02-17-traffic_safety_kde.md
+++ b/_posts/2021-02-17-traffic_safety_kde.md
@@ -35,13 +35,12 @@ summary: Traffic safety in urban areas remains a significant challenge globally.
   limitations of traditional methods, and offering practical solutions for real-world
   applications.
 tags:
-- Traffic safety
-- Traffic accident hotspots
-- Data analysis
+- Transportation
+- Data Analysis
 - Python
-- Kernel density estimation
-- Kde
-- Bash
+- Statistical Modeling
+- Mathematical Modeling
+- Programming
 title: 'Traffic Safety with Data: A Comprehensive Approach Using Kernel Density Estimation
   (KDE) to Detect Traffic Accident Hotspots'
 ---

--- a/_posts/2021-03-01-polynomial_regression.md
+++ b/_posts/2021-03-01-polynomial_regression.md
@@ -25,11 +25,9 @@ seo_title: 'Polynomial Regression: Why It’s Still Linear Regression'
 seo_type: article
 summary: Polynomial regression models the relationship between the response variable and explanatory variables using a pth-order polynomial. Although this suggests a nonlinear relationship between the response and explanatory variables, it is still linear regression, as the linearity pertains to the relationship between the response variable and the regression coefficients.
 tags:
-- Polynomial regression
-- Regression analysis
-- Statistical modeling
-- Linear regression
-- Machine learning algorithms
+- Regression
+- Statistical Modeling
+- Machine Learning
 title: 'Understanding Polynomial Regression: Why It''s Still Linear Regression'
 ---
 

--- a/_posts/2021-03-01-type_1_type_2_errors.md
+++ b/_posts/2021-03-01-type_1_type_2_errors.md
@@ -27,11 +27,8 @@ summary: This article explains the fundamental concepts behind Type I and Type I
   errors in statistical testing, covering their causes, how to minimize them, and
   the critical role of statistical power and sample size in data science.
 tags:
-- Statistical testing
-- Type ii error
-- Type i error
-- Data science
-- Hypothesis testing
+- Hypothesis Testing
+- Data Science
 title: 'Understanding Type I and Type II Errors in Statistical Testing: How to Minimize
   False Conclusions'
 ---

--- a/_posts/2021-04-01-asymmetric_confidence_interval.md
+++ b/_posts/2021-04-01-asymmetric_confidence_interval.md
@@ -28,11 +28,10 @@ summary: Asymmetric confidence intervals can result from the nature of your data
   the statistical method used. This article explores the causes and implications of
   these intervals for interpreting research results.
 tags:
-- Asymmetric ci
-- Confidence intervals
-- Bash
-- Data distribution
-- Statistical tests
+- Confidence Intervals
+- Programming
+- Probability
+- Hypothesis Testing
 - Python
 title: 'Understanding Asymmetric Confidence Intervals: Causes and Implications'
 ---

--- a/_posts/2021-04-27-forest_fires_kde.md
+++ b/_posts/2021-04-27-forest_fires_kde.md
@@ -29,15 +29,10 @@ seo_title: GIS-Based Forest Fire Hotspot Identification
 seo_type: article
 summary: This article explores the application of GIS-based techniques, such as Kernel Density Estimation (KDE), Getis-Ord Gi*, and Anselin Local Moran's I, in identifying forest fire hotspots. The study focuses on Belait District, Brunei Darussalam, and validates hotspot results using contributory factors like population density, precipitation, elevation, and vegetation cover.
 tags:
-- Anselin local moran’s i
-- Gis
-- Forest fires
-- Getis-ord gi*
+- Climate and Environment
 - Python
-- Kernel density estimation
-- Bash
-- bash
-- python
+- Statistical Modeling
+- Programming
 title: 'GIS-Based Forest Fire Hotspot Identification: A Comprehensive Approach Using Contributory Factors'
 ---
 

--- a/_posts/2021-04-30-big_data_climate_change_mitigation.md
+++ b/_posts/2021-04-30-big_data_climate_change_mitigation.md
@@ -26,11 +26,10 @@ summary: In this article, we examine the intersection of big data and climate sc
   focusing on how large-scale data collection and analysis are transforming our ability
   to monitor, predict, and mitigate climate change.
 tags:
-- Big data
-- Climate change
-- Environmental monitoring
-- Predictive analytics
-- Satellite data
+- Data Engineering
+- Climate and Environment
+- Model Monitoring
+- Machine Learning
 title: Big Data for Climate Change Mitigation
 ---
 

--- a/_posts/2021-05-01-rare_labels_machine_learning.md
+++ b/_posts/2021-05-01-rare_labels_machine_learning.md
@@ -29,12 +29,9 @@ summary: This article covers how rare labels in categorical variables can impact
   learning models, particularly tree-based methods, and why it's important to address
   these rare labels during preprocessing.
 tags:
-- Mercedes-benz greener manufacturing challenge
-- Categorical variables
 - Python
-- Overfitting
-- Rare labels
-- Feature engineering
+- Regularization
+- Feature Engineering
 title: Handling Rare Labels in Categorical Variables in Machine Learning
 ---
 

--- a/_posts/2021-05-10-estimating_uncertainty_neural_networks_using_monte_carlo_dropout.md
+++ b/_posts/2021-05-10-estimating_uncertainty_neural_networks_using_monte_carlo_dropout.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Neural Networks
+- Machine Learning
 classes: wide
 date: '2021-05-10'
 excerpt: This article discusses Monte Carlo dropout and how it is used to estimate
@@ -20,6 +20,8 @@ keywords:
 - Multi-class classification
 - Neural networks
 - Entropy
+redirect_from:
+- '/neural networks/estimating_uncertainty_neural_networks_using_monte_carlo_dropout/'
 seo_description: How Monte Carlo dropout estimates uncertainty in neural networks for multi-class classification, and the methods used to derive uncertainty scores.
 seo_title: Monte Carlo Dropout for Uncertainty Estimation
 seo_type: article
@@ -28,10 +30,10 @@ summary: In this article, we explore how to estimate uncertainty in neural netwo
   and dive into methods like entropy, predictive probabilities, and error-function-based
   uncertainty estimation.
 tags:
-- Monte carlo dropout
-- Uncertainty quantification
-- Machine learning
-- Multi-class classification
+- Monte Carlo
+- Confidence Intervals
+- Machine Learning
+- Classification
 title: Estimating Uncertainty in Neural Networks Using Monte Carlo Dropout
 ---
 

--- a/_posts/2021-05-11-predictive_maintenance_algorithms_classical_vs_machine_learning_approaches.md
+++ b/_posts/2021-05-11-predictive_maintenance_algorithms_classical_vs_machine_learning_approaches.md
@@ -29,12 +29,10 @@ summary: A deep dive into how classical predictive maintenance algorithms, such 
   ARIMA, compare with machine learning models, examining their strengths and weaknesses
   in terms of performance, accuracy, and scalability.
 tags:
-- Predictive maintenance
-- Statistical models
-- Machine learning
-- Predictive algorithms
-- Arima
-- Industrial analytics
+- Predictive Maintenance
+- Statistical Modeling
+- Machine Learning
+- Time Series
 title: 'A Comparison of Predictive Maintenance Algorithms: Classical vs. Machine Learning
   Approaches'
 ---

--- a/_posts/2021-05-12-understanding_heart_rate_variability_through_lens_coefficient_variation_health_monitoring.md
+++ b/_posts/2021-05-12-understanding_heart_rate_variability_through_lens_coefficient_variation_health_monitoring.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Health Monitoring
+- Healthcare
 classes: wide
 date: '2021-05-12'
 excerpt: Discover the significance of heart rate variability (HRV) and how the coefficient
@@ -19,6 +19,8 @@ keywords:
 - Cardiovascular health
 - Fitness monitoring
 - Stress assessment
+redirect_from:
+- '/health monitoring/understanding_heart_rate_variability_through_lens_coefficient_variation_health_monitoring/'
 seo_description: Explore how the coefficient of variation offers deeper insights into
   heart rate variability and health monitoring.
 seo_title: Understanding HRV and Coefficient of Variation
@@ -27,9 +29,7 @@ summary: This article delves into heart rate variability (HRV), focusing on the 
   of variation (CV) as a critical metric for understanding cardiovascular health and
   overall well-being.
 tags:
-- Heart rate variability
-- Coefficient of variation
-- Health metrics
+- Descriptive Statistics
 title: Understanding Heart Rate Variability Through the Lens of the Coefficient of
   Variation in Health Monitoring
 ---

--- a/_posts/2021-05-26-kernel_math.md
+++ b/_posts/2021-05-26-kernel_math.md
@@ -38,13 +38,11 @@ summary: Kernel Density Estimation (KDE) is a non-parametric method used to esti
   With a focus on practical insights and theoretical rigor, the article offers a comprehensive
   guide to understanding KDE.
 tags:
-- Non-parametric statistics
-- Multivariate kde
-- Kernel functions
-- Machine learning
-- Kernel density estimation
-- Bandwidth selection
-- Data science
+- Nonparametric Methods
+- Multivariate Analysis
+- Machine Learning
+- Statistical Modeling
+- Data Science
 title: The Math Behind Kernel Density Estimation
 ---
 

--- a/_posts/2021-06-01-customer_segmentation.md
+++ b/_posts/2021-06-01-customer_segmentation.md
@@ -31,11 +31,10 @@ summary: This article provides an in-depth exploration of RFM segmentation, expl
   groups, improve marketing, and enhance retention strategies using clustering techniques.
 tags:
 - Clustering
-- Unsupervised learning
-- Customer retention
-- Business strategy
-- Data science
-- Rfm segmentation
+- Unsupervised Learning
+- Customer Analytics
+- Business Intelligence
+- Data Science
 - Python
 title: 'RFM Segmentation: A Powerful Customer Segmentation Technique'
 ---

--- a/_posts/2021-07-26-regression_tasks.md
+++ b/_posts/2021-07-26-regression_tasks.md
@@ -33,12 +33,8 @@ seo_description: How to select a regression algorithm based on complexity, dimen
 seo_title: Choosing the Right Regression Model
 seo_type: article
 tags:
-- Polynomial regression
-- Support vector regression
 - Regression
-- Gaussian process regression
-- Machine learning algorithms
-- Principal component regression
+- Machine Learning
 - Python
 title: 'A Guide to Regression Tasks: Choosing the Right Approach'
 ---

--- a/_posts/2021-08-01-building_linear_regression_scratch.md
+++ b/_posts/2021-08-01-building_linear_regression_scratch.md
@@ -25,9 +25,8 @@ summary: This article provides a detailed algorithmic approach to building a Lin
   Regression model from scratch, covering theory, Python code implementation, and
   performance evaluation.
 tags:
-- Linear regression
+- Regression
 - Python
-- Normal equation
 title: 'Building Linear Regression from Scratch: A Detailed Algorithmic Approach'
 ---
 

--- a/_posts/2021-09-24-crime_analysis.md
+++ b/_posts/2021-09-24-crime_analysis.md
@@ -29,10 +29,8 @@ summary: This article delves into the application of K-means clustering in crime
   and predict criminal activity. The article includes a detailed exploration of data
   mining, clustering methods, and practical use cases.
 tags:
-- Data mining
-- K-means clustering
-- Machine learning
-- Crime analysis
+- Clustering
+- Machine Learning
 - Python
 title: 'Crime Analysis Using K-Means Clustering: Enhancing Security through Data Mining'
 ---

--- a/_posts/2021-10-05-data_preprocessing_pipelines.md
+++ b/_posts/2021-10-05-data_preprocessing_pipelines.md
@@ -25,9 +25,9 @@ seo_type: article
 summary: This post outlines the key steps in constructing data preprocessing pipelines
   using tools like scikit-learn to ensure consistent model inputs.
 tags:
-- Data preprocessing
-- Machine learning
-- Feature engineering
+- Data Quality
+- Machine Learning
+- Feature Engineering
 title: Designing Effective Data Preprocessing Pipelines
 ---
 

--- a/_posts/2021-10-15-decision_tree_algorithms.md
+++ b/_posts/2021-10-15-decision_tree_algorithms.md
@@ -25,9 +25,9 @@ seo_type: article
 summary: This article walks through the basics of decision tree construction and explains
   common pruning methods to create better models.
 tags:
-- Decision trees
+- Decision Trees
 - Classification
-- Overfitting
+- Regularization
 title: Demystifying Decision Tree Algorithms
 ---
 

--- a/_posts/2021-11-10-model_evaluation_metrics.md
+++ b/_posts/2021-11-10-model_evaluation_metrics.md
@@ -25,9 +25,7 @@ seo_type: article
 summary: Learn how to interpret common classification and regression metrics to choose
   the best model for your data.
 tags:
-- Accuracy
-- F1-score
-- Rmse
+- Model Evaluation
 title: A Guide to Model Evaluation Metrics
 ---
 

--- a/_posts/2021-12-24-linear_programming.md
+++ b/_posts/2021-12-24-linear_programming.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Operations Research
+- Economics
 classes: wide
 date: '2021-12-24'
 excerpt: Linear Programming is the foundation of optimization in operations research.
@@ -31,15 +31,13 @@ keywords:
 - Scalable lp solutions
 - First-order methods
 - Computational optimization
+redirect_from:
+- '/operations research/linear_programming/'
 seo_description: Linear programming from Simplex and interior-point methods to PDLP, a scalable first-order solver for very large LP problems.
 seo_title: Linear Programming and PDLP at Scale
 seo_type: article
 tags:
-- Primal-dual hybrid gradient method
-- First-order methods
-- Computational optimization
-- Linear programming
-- Or-tools
+- Optimization
 title: 'Exploring Classic Linear Programming (LP) Problems and Scalable Solutions:
   A Deep Dive into PDLP'
 ---

--- a/_posts/2021-12-25-suply_chain.md
+++ b/_posts/2021-12-25-suply_chain.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Optimization
+- Mathematics
 classes: wide
 date: '2021-12-25'
 excerpt: Discover how data science enhances supply chain optimization and industrial
@@ -29,13 +29,15 @@ keywords:
 - Resource allocation
 - Supply chain optimization
 - Data science in supply chain
+redirect_from:
+- '/optimization/suply_chain/'
 seo_description: How data science drives supply chain optimization and industrial network analysis through predictive analytics, IoT, and graph theory.
 seo_title: Data-Driven Supply Chain Optimization
 seo_type: article
 tags:
-- Industrial network analysis
-- Data science
-- Supply chain optimization
+- Graph Theory
+- Data Science
+- Supply Chain
 title: Supply Chain Optimization and Industrial Network Analysis Using Data Science
 ---
 

--- a/_posts/2021-12-31-FDM.md
+++ b/_posts/2021-12-31-FDM.md
@@ -31,16 +31,10 @@ summary: This article explains how Finite Difference Methods (FDM) are applied t
   solve the Black-Scholes-Merton equation for option pricing, focusing on explicit
   and implicit schemes, as well as stability analysis.
 tags:
-- Numerical analysis
-- Financial engineering
-- Finite difference methods
-- Bash
+- Finance
+- Numerical Methods
+- Programming
 - Python
-- Black-scholes-merton equation
-- Option pricing
-- Implicit scheme
-- Explicit scheme
-- Numerical methods
 title: 'Finite Difference Methods and the Black-Scholes-Merton Equation: A Numerical
   Approach to Option Pricing'
 ---

--- a/_posts/2022-01-02-OLS.md
+++ b/_posts/2022-01-02-OLS.md
@@ -28,11 +28,8 @@ seo_description: 'The mathematical connection between OLS and Theil-Sen estimato
 seo_title: 'OLS and Theil-Sen Estimators: Understanding Their Connection'
 seo_type: article
 tags:
-- Weighted averages
-- Robust estimators
-- Regression analysis
-- Ols
-- Theil-sen
+- Robust Statistics
+- Regression
 title: Connection Between OLS and Theil-Sen Estimators
 ---
 

--- a/_posts/2022-01-03-granger_causality_test.md
+++ b/_posts/2022-01-03-granger_causality_test.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Statistics
 classes: wide
 date: '2022-01-03'
 excerpt: Explore the Granger causality test, a vital tool for determining causal relationships
@@ -21,6 +20,8 @@ keywords:
 - Econometrics
 - Causality in finance
 - Temporal causality
+redirect_from:
+- '/data science/statistics/granger_causality_test/'
 seo_description: A detailed exploration of the Granger causality test, its theoretical
   foundations, and applications in economics, climate science, and finance.
 seo_title: Granger Causality in Time-Series Data
@@ -29,9 +30,8 @@ summary: The Granger causality test is a key method for identifying causal relat
   in time-series data. This article covers its principles, methodology, and practical
   applications in fields such as economics, climate science, and finance.
 tags:
-- Granger causality
-- Time-series analysis
-- Econometrics
+- Time Series
+- Economics
 - Finance
 title: 'Granger Causality Test: Assessing Temporal Causal Relationships in Time-Series
   Data'

--- a/_posts/2022-02-17-staff_schedulling.md
+++ b/_posts/2022-02-17-staff_schedulling.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Optimization
+- Mathematics
 classes: wide
 date: '2022-02-17'
 excerpt: Discover how linear programming and Python's PuLP library can efficiently solve staff scheduling challenges, minimizing costs while meeting operational demands.
@@ -27,14 +27,15 @@ keywords:
 - Constraint programming
 - Bash
 - Python
+redirect_from:
+- '/optimization/staff_schedulling/'
 seo_description: Learn how to use linear programming with the PuLP library in Python to optimize staff scheduling and minimize costs in a 24/7 operational environment.
 seo_title: Staff Scheduling with Linear Programming in Python
 seo_type: article
 summary: This article discusses using linear programming and Python’s PuLP library to optimize staff scheduling, focusing on cost minimization and meeting operational requirements efficiently.
 tags:
-- Linear programming
-- Scheduling
-- Bash
+- Optimization
+- Programming
 - Python
 title: Optimizing Staff Scheduling with Linear Programming
 ---

--- a/_posts/2022-03-14-levenes_test_vs_bartletts_test_checking_homogeneity_variances.md
+++ b/_posts/2022-03-14-levenes_test_vs_bartletts_test_checking_homogeneity_variances.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Hypothesis Testing
+- Statistics
 classes: wide
 date: '2022-03-14'
 excerpt: Levene's Test and Bartlett's Test are key tools for checking homogeneity of variances in data. Learn when to use each test, based on normality assumptions, and how they relate to tests like ANOVA.
@@ -18,16 +18,16 @@ keywords:
 - Homogeneity of variances
 - Anova
 - Hypothesis testing
+redirect_from:
+- '/hypothesis testing/levenes_test_vs_bartletts_test_checking_homogeneity_variances/'
 seo_description: 'Comparing Levene''s and Bartlett''s tests for homogeneity of variances, when to use each based on normality, and how they pair with ANOVA.'
 seo_title: 'Levene''s Test vs. Bartlett''s Test for Variance'
 seo_type: article
 summary: This article provides a detailed comparison between Levene's Test and Bartlett’s Test for assessing the homogeneity of variances in data. It explains the differences in when to use these tests—parametric vs. non-parametric data, normal vs. non-normal data—and their applications alongside statistical tests like ANOVA.
 tags:
-- Levene's test
-- Bartlett’s test
-- Homogeneity of variances
-- Anova
-- Parametric and non-parametric tests
+- Descriptive Statistics
+- Hypothesis Testing
+- Nonparametric Methods
 title: 'Levene''s Test vs. Bartlett’s Test: Checking for Homogeneity of Variances'
 ---
 

--- a/_posts/2022-03-15-bayesian_ab_testing.md
+++ b/_posts/2022-03-15-bayesian_ab_testing.md
@@ -32,8 +32,8 @@ seo_description: How Bayesian A/B testing gives more nuanced insight into conver
 seo_title: 'Bayesian A/B Testing: Enhancing Conversion Rate Analysis'
 seo_type: article
 tags:
-- A/b testing
-- Bayesian methods
+- Experimental Design
+- Bayesian Statistics
 - Python
 title: A Guide to Bayesian A/B Testing for Conversion Rates
 ---

--- a/_posts/2022-05-26-networks.md
+++ b/_posts/2022-05-26-networks.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Optimization
+- Mathematics
 classes: wide
 date: '2022-05-26'
 excerpt: Learn how graph theory is applied to network analysis in production systems
@@ -25,12 +25,13 @@ keywords:
 - Network models in production
 - Operational optimization
 - Industrial network analysis
+redirect_from:
+- '/optimization/networks/'
 seo_description: How graph theory improves network analysis in production systems, from bottleneck identification to resource allocation and supply chain optimization.
 seo_title: Graph Theory in Production Systems
 seo_type: article
 tags:
-- Graph theory
-- Network analysis
+- Graph Theory
 title: Graph Theory Applications in Network Analysis for Production Systems
 ---
 

--- a/_posts/2022-07-23-statistical_tests.md
+++ b/_posts/2022-07-23-statistical_tests.md
@@ -34,8 +34,8 @@ summary: This article explains the universal structure of statistical tests, foc
   on the comparison between observed and expected data that forms the foundation of
   hypothesis testing and statistical inference.
 tags:
-- Statistical tests
-- Data analysis
+- Hypothesis Testing
+- Data Analysis
 title: The Structure Behind Most Statistical Tests
 ---
 

--- a/_posts/2022-07-26-features.md
+++ b/_posts/2022-07-26-features.md
@@ -35,8 +35,8 @@ summary: This article delves into feature discretization as a technique to enhan
   continuous variables can optimize data analysis and machine learning models, offering
   improved interpretability and performance in predictive tasks.
 tags:
-- Feature engineering
-- Linear models
+- Feature Engineering
+- Regression
 title: 'Non-Linear Insights with Linear Models: Feature Discretization'
 ---
 

--- a/_posts/2022-07-26-geospatial_data_public_health_insights.md
+++ b/_posts/2022-07-26-geospatial_data_public_health_insights.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Public Health
 classes: wide
 date: '2022-07-26'
 excerpt: Spatial epidemiology combines geospatial data with data science techniques
@@ -22,6 +21,8 @@ keywords:
 - Public health
 - Gis
 - Data science
+redirect_from:
+- '/data science/public health/geospatial_data_public_health_insights/'
 seo_description: How geospatial data is transforming public health, and how spatial epidemiology tracks disease outbreaks to guide health interventions.
 seo_title: Spatial Epidemiology and Geospatial Data
 seo_type: article
@@ -30,11 +31,8 @@ summary: This article explores the importance of geospatial data in spatial epid
   the integration of spatial data with data science methods and how these insights
   are applied to public health decision-making and intervention strategies.
 tags:
-- Spatial epidemiology
-- Geospatial data
-- Disease surveillance
-- Data science
-- Public health
+- Epidemiology
+- Data Science
 title: 'Spatial Epidemiology: Geospatial Data for Public Health Insights'
 ---
 

--- a/_posts/2022-08-14-wald_test_hypothesis_testing_regression_analysis.md
+++ b/_posts/2022-08-14-wald_test_hypothesis_testing_regression_analysis.md
@@ -29,11 +29,9 @@ summary: The Wald test is a fundamental statistical method used to evaluate hypo
   practical applications, and interpretation of the Wald test in various regression
   models.
 tags:
-- Wald test
-- Logistic regression
-- Poisson regression
-- Hypothesis testing
-- Regression models
+- Regression
+- Probability
+- Hypothesis Testing
 title: 'Wald Test: Hypothesis Testing in Regression Analysis'
 ---
 

--- a/_posts/2022-08-15-linear_relashionships.md
+++ b/_posts/2022-08-15-linear_relashionships.md
@@ -28,12 +28,8 @@ summary: This article covers the importance of understanding linear assumptions 
   machine learning models, which models assume linearity, and what steps can be taken
   when the assumption is not met.
 tags:
-- Linear models
-- Logistic regression
-- Lda
-- Principal component regression
-- Feature engineering
-- House price prediction
+- Regression
+- Feature Engineering
 title: 'Linear Relationships in Machine Learning Models: Why They Matter'
 ---
 

--- a/_posts/2022-09-27-entropy_information_theory.md
+++ b/_posts/2022-09-27-entropy_information_theory.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Information Theory
+- Mathematics
 classes: wide
 date: '2022-09-27'
 excerpt: Explore entropy's role in thermodynamics, information theory, and quantum
@@ -21,6 +21,8 @@ keywords:
 - Quantum mechanics
 - Statistical mechanics
 - Maximum entropy principle
+redirect_from:
+- '/information theory/entropy_information_theory/'
 seo_description: Entropy across thermodynamics, statistical mechanics, and information theory, from classical formulations to quantum mechanics.
 seo_title: 'Entropy and Information Theory: A Comprehensive Analysis'
 seo_type: article
@@ -29,10 +31,9 @@ summary: This article provides an in-depth exploration of entropy, tracing its r
   It discusses entropy's applications across various fields, including physics, data
   science, and cosmology.
 tags:
-- Entropy
-- Information theory
-- Statistical mechanics
-- Quantum physics
+- Probability
+- Information Theory
+- Mathematical Modeling
 title: 'Entropy and Information Theory: A Detailed Exploration'
 ---
 

--- a/_posts/2022-10-15-time_series_decomposition.md
+++ b/_posts/2022-10-15-time_series_decomposition.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Time Series
 classes: wide
 date: '2022-10-15'
 excerpt: Learn how time series decomposition reveals trend, seasonality, and residual
@@ -20,6 +19,8 @@ keywords:
 - Seasonality
 - Forecasting
 - Decomposition
+redirect_from:
+- '/data science/time series/time_series_decomposition/'
 seo_description: Discover how to separate trend and seasonal patterns from a time
   series using additive or multiplicative decomposition.
 seo_title: Time Series Decomposition Made Simple
@@ -27,9 +28,9 @@ seo_type: article
 summary: This article explains how decomposing a time series helps isolate long-term
   trends and recurring seasonal effects so you can model data more effectively.
 tags:
-- Time series
+- Time Series
 - Forecasting
-- Data analysis
+- Data Analysis
 - Python
 title: 'Time Series Decomposition: Separating Trend and Seasonality'
 ---

--- a/_posts/2022-10-30-iot_sensor_data_backbone_predictive_maintenance.md
+++ b/_posts/2022-10-30-iot_sensor_data_backbone_predictive_maintenance.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- IoT
+- Predictive Maintenance
 classes: wide
 date: '2022-10-30'
 excerpt: Learn how IoT-enabled sensors like vibration, temperature, and pressure sensors
@@ -20,6 +20,8 @@ keywords:
 - Predictive maintenance
 - Real-time monitoring
 - Industrial iot
+redirect_from:
+- '/iot/iot_sensor_data_backbone_predictive_maintenance/'
 seo_description: How IoT devices and sensors supply the real-time data behind predictive maintenance, and how sensor types contribute to equipment health monitoring.
 seo_title: How IoT and Sensor Data Power Predictive Maintenance
 seo_type: article
@@ -27,11 +29,9 @@ summary: This article delves into the critical role IoT and sensor data play in 
   maintenance, covering different types of sensors and their applications, the importance
   of real-time monitoring, and how the data is processed to optimize maintenance strategies.
 tags:
-- Iot
-- Sensor data
-- Predictive maintenance
-- Real-time monitoring
-- Industrial iot
+- Industrial IoT
+- Predictive Maintenance
+- Model Monitoring
 title: 'IoT and Sensor Data: The Backbone of Predictive Maintenance'
 ---
 

--- a/_posts/2022-10-31-Jacknife.md
+++ b/_posts/2022-10-31-Jacknife.md
@@ -32,8 +32,7 @@ seo_description: Learn about the jackknife technique, a resampling method for es
 seo_title: The Jackknife Technique in Statistics
 seo_type: article
 tags:
-- Jackknife
-- Resampling methods
+- Monte Carlo
 title: 'The Jackknife Technique: Understanding Its Applications and Benefits'
 ---
 

--- a/_posts/2022-11-30-Bootstrap.md
+++ b/_posts/2022-11-30-Bootstrap.md
@@ -36,8 +36,7 @@ seo_type: article
 summary: An overview of bootstrapping, its significance as a resampling method in
   statistics, and how it is used to estimate the sampling distribution of a statistic.
 tags:
-- Bootstrapping
-- Resampling
+- Monte Carlo
 - Python
 title: 'Understanding Bootstrapping: A Resampling Method in Statistics'
 ---

--- a/_posts/2022-12-25-probability_machine_learning.md
+++ b/_posts/2022-12-25-probability_machine_learning.md
@@ -31,8 +31,8 @@ seo_description: An in-depth exploration of key probability distributions in mac
 seo_title: Probability Distributions in Machine Learning
 seo_type: article
 tags:
-- Probability distributions
-- Data analysis
+- Probability
+- Data Analysis
 title: Probability Distributions in Machine Learning
 ---
 

--- a/_posts/2022-12-30-simpsons_paradox.md
+++ b/_posts/2022-12-30-simpsons_paradox.md
@@ -16,11 +16,9 @@ seo_description: 'The theoretical foundations of Simpson''s Paradox, and how lur
 seo_title: 'Simpson''s Paradox and Lurking Variables'
 seo_type: article
 tags:
-- Simpson's paradox
-- Lurking variables
-- Data aggregation
-- Statistical paradoxes
-- Data visualization
+- Correlation
+- Data Quality
+- Data Visualization
 title: 'Simpson’s Paradox: Theoretical Foundations and Implications in Data Analysis'
 ---
 

--- a/_posts/2022-12-31-PCA_explained.md
+++ b/_posts/2022-12-31-PCA_explained.md
@@ -40,8 +40,7 @@ summary: Principal Component Analysis (PCA) is a powerful technique in data scie
   or to improve machine learning models, this guide will help you grasp its key principles,
   including how to interpret explained variance and identify significant components.
 tags:
-- Pca
-- Dimensionality reduction
+- Dimensionality Reduction
 - Python
 title: 'Understanding PCA: A Step-by-Step Guide to Principal Component Analysis'
 ---

--- a/_posts/2023-01-01-error_coefficientes.md
+++ b/_posts/2023-01-01-error_coefficientes.md
@@ -35,11 +35,8 @@ summary: This article explores how error terms are handled in both multiple line
   regression and binary logistic regression, emphasizing their roles in statistical
   model performance and accuracy.
 tags:
-- Regression models
-- Error terms
-- Multiple linear regression
-- Binary logistic regression
-- Statistical models
+- Regression
+- Statistical Modeling
 title: The Role of Error Terms in Multiple Linear Regression and Binary Logistic Regression
 ---
 

--- a/_posts/2023-01-08-crownd_behaviour.md
+++ b/_posts/2023-01-08-crownd_behaviour.md
@@ -30,11 +30,8 @@ seo_title: Mathematical Models of Pedestrian Behavior
 seo_type: article
 subtitle: Understanding Pedestrian Behavior through Mathematical Models
 tags:
-- Mathematical modeling
-- Pedestrian behavior
-- Urban planning
-- Crowd management
-- Traffic control
+- Mathematical Modeling
+- Transportation
 title: Walking the Mathematical Path
 ---
 

--- a/_posts/2023-02-17-ab_testing.md
+++ b/_posts/2023-02-17-ab_testing.md
@@ -33,11 +33,10 @@ seo_description: 'The statistics behind sequential testing in A/B tests: SPRT, e
 seo_title: Sequential Testing Methods for A/B Tests
 seo_type: article
 tags:
-- A/b testing
-- Sequential testing
-- Statistical methods
+- Experimental Design
+- Statistical Modeling
 - R
-- Javascript
+- Programming
 - Python
 title: Advanced Statistical Methods for Efficient A/B Testing
 ---

--- a/_posts/2023-05-05-Mean_Time_Between_Failures.md
+++ b/_posts/2023-05-05-Mean_Time_Between_Failures.md
@@ -27,9 +27,7 @@ seo_type: article
 summary: A comprehensive guide on Mean Time Between Failures (MTBF), covering its
   calculation, use cases, strengths, and weaknesses in reliability engineering.
 tags:
-- Mtbf
-- Reliability metrics
-- Predictive maintenance
+- Predictive Maintenance
 - Python
 title: Understanding Mean Time Between Failures (MTBF)
 ---

--- a/_posts/2023-07-23-VAR.md
+++ b/_posts/2023-07-23-VAR.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Finance
+- Economics
 classes: wide
 date: '2023-07-23'
 excerpt: A detailed exploration of Value at Risk (VaR), covering its different types,
@@ -28,14 +28,16 @@ keywords:
 - Var in portfolio management
 - Var types
 - Financial risk metrics
+redirect_from:
+- '/finance/VAR/'
 seo_description: Explore the key concepts, types, and applications of Value at Risk
   (VaR) in portfolio management, including Parametric VaR, Historical VaR, and Monte
   Carlo VaR.
 seo_title: Comprehensive Guide to Value at Risk (VaR) and Its Types
 seo_type: article
 tags:
-- Value at risk
-- Risk management
+- Finance
+- Risk Management
 title: Understanding Value at Risk (VaR) and Its Types
 ---
 

--- a/_posts/2023-07-26-customerlifetimevalue.md
+++ b/_posts/2023-07-26-customerlifetimevalue.md
@@ -38,9 +38,8 @@ summary: This article provides a comprehensive exploration of Customer Lifetime 
   in data-driven marketing strategies. It also covers how CLV can be integrated with
   other business data to optimize customer retention and enhance profitability.
 tags:
-- Clv
-- Predictive analytics
-- Marketing strategy
+- Customer Analytics
+- Machine Learning
 - Python
 title: 'Customer Lifetime Value: An In-Depth Exploration for Data Practitioners and
   Marketers'

--- a/_posts/2023-08-12-guassian_processes.md
+++ b/_posts/2023-08-12-guassian_processes.md
@@ -20,9 +20,8 @@ seo_description: Explore Gaussian Processes and their application in time-series
 seo_title: 'Gaussian Processes for Time Series: A Deep Dive in Python'
 seo_type: article
 tags:
-- Gaussian processes
-- Time series
-- Bayesian inference
+- Time Series
+- Bayesian Statistics
 - Python
 title: Gaussian Processes for Time-Series Analysis in Python
 ---

--- a/_posts/2023-08-13-shared_nearest_neighbors.md
+++ b/_posts/2023-08-13-shared_nearest_neighbors.md
@@ -33,12 +33,11 @@ summary: Shared Nearest Neighbors (SNN) is a distance metric designed to enhance
   metrics like Euclidean and Manhattan, providing robust performance in complex data
   scenarios.
 tags:
-- Machine learning
-- Outlier detection
+- Machine Learning
+- Anomaly Detection
 - Clustering
-- Data science
-- Distance metrics
-- K-nearest neighbors
+- Data Science
+- Mathematical Modeling
 - Python
 title: Exploring Shared Nearest Neighbors (SNN) for Outlier Detection
 ---

--- a/_posts/2023-08-21-demystifying_data_science.md
+++ b/_posts/2023-08-21-demystifying_data_science.md
@@ -41,10 +41,10 @@ summary: This article explores the role of data science in business, highlightin
   chain optimization, and predictive analytics, showcasing how companies can leverage
   data science for competitive advantage.
 tags:
-- Data science
-- Business intelligence
-- Machine learning
-- Data analysis
+- Data Science
+- Business Intelligence
+- Machine Learning
+- Data Analysis
 title: Demystifying Data Science
 ---
 

--- a/_posts/2023-08-21-large_languague_models.md
+++ b/_posts/2023-08-21-large_languague_models.md
@@ -35,10 +35,9 @@ summary: An exploration into the challenges faced by Large Language Models (LLMs
   dependent on these data sources, and the broader implications for ethical AI development
   and the future of machine learning.
 tags:
-- Llm
-- Open-source data
-- Machine learning models
-- Ai ethics
+- Natural Language Processing
+- Machine Learning
+- Ethics
 title: The Vulnerability of Large Language Models to the Closure of Open-Source Data
   Platforms
 ---

--- a/_posts/2023-08-22-paulerdos.md
+++ b/_posts/2023-08-22-paulerdos.md
@@ -28,10 +28,7 @@ seo_title: 'Paul Erdős: The Prodigy Who Changed Mathematics'
 seo_type: article
 subtitle: A Mathematician for the Ages
 tags:
-- Paul erdős
-- Mathematical genius
-- Number theory
-- Collaboration in science
+- Number Theory
 title: The Life and Legacy of Paul Erdős
 ---
 

--- a/_posts/2023-08-23-multivariate_analysis_variance_vs_anova.md
+++ b/_posts/2023-08-23-multivariate_analysis_variance_vs_anova.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Multivariate Analysis
+- Statistics
 classes: wide
 date: '2023-08-23'
 excerpt: Learn the key differences between MANOVA and ANOVA, and when to apply them
@@ -19,6 +19,8 @@ keywords:
 - Experimental design
 - Clinical trials
 - Multivariate analysis
+redirect_from:
+- '/multivariate analysis/multivariate_analysis_variance_vs_anova/'
 seo_description: The differences between MANOVA and ANOVA, and when to use each in experimental designs such as clinical trials with multiple outcome variables.
 seo_title: 'MANOVA vs. ANOVA: Differences and Use Cases'
 seo_type: article
@@ -28,11 +30,9 @@ summary: Multivariate Analysis of Variance (MANOVA) and Analysis of Variance (AN
   This article explores their differences and application in experimental designs
   like clinical trials.
 tags:
-- Manova
-- Anova
-- Multivariate statistics
-- Experimental design
-- Clinical trials
+- Multivariate Analysis
+- Hypothesis Testing
+- Experimental Design
 title: 'Multivariate Analysis of Variance (MANOVA) vs. ANOVA: When to Analyze Multiple
   Dependent Variables'
 ---

--- a/_posts/2023-08-25-rr_functions_rolling_windows.md
+++ b/_posts/2023-08-25-rr_functions_rolling_windows.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- R Programming
+- Programming
 classes: wide
 date: '2023-08-25'
 excerpt: Explore the `runner` package in R, which allows applying any R function to
@@ -24,6 +24,8 @@ keywords:
 - Dplyr runner integration
 - Rolling regression r
 - R
+redirect_from:
+- '/r programming/rr_functions_rolling_windows/'
 seo_description: How to apply any function on rolling windows in R with the runner package, supporting custom window sizes, lags, and date-based indexing.
 seo_title: Rolling Window Functions in R with runner
 seo_type: article
@@ -31,10 +33,8 @@ summary: This article explores the `runner` package in R, detailing how to apply
   to rolling windows of data with custom window sizes, lags, and indexing, particularly
   useful for time series and cumulative operations.
 tags:
-- Rolling windows
-- Time series analysis
-- Data manipulation
-- Statistical modeling
+- Time Series
+- Statistical Modeling
 - R
 title: Applying R Functions on Rolling Windows Using the `runner` Package
 ---

--- a/_posts/2023-08-30-ethics_data_science.md
+++ b/_posts/2023-08-30-ethics_data_science.md
@@ -30,9 +30,9 @@ seo_title: 'Ethics in Data Science: Privacy, Bias, and Impact'
 seo_type: article
 subtitle: A Comprehensive Guide to Privacy, Bias, Social Impact and Responsible Decision-Making
 tags:
-- Data science
-- Artificial intelligence
-- Machine learning
+- Data Science
+- Artificial Intelligence
+- Machine Learning
 - Ethics
 title: Ethics in Data Science
 ---

--- a/_posts/2023-09-01-regression_path_analysis.md
+++ b/_posts/2023-09-01-regression_path_analysis.md
@@ -30,9 +30,8 @@ summary: Regression and path analysis are both important statistical methods, bu
   This comprehensive article delves into the theoretical and practical distinctions
   between these two methods.
 tags:
-- Regression analysis
-- Path analysis
-- Structural equation modeling
+- Regression
+- Statistical Modeling
 title: Understanding the Difference Between Regression and Path Analysis
 ---
 

--- a/_posts/2023-09-03-binary_classification.md
+++ b/_posts/2023-09-03-binary_classification.md
@@ -29,9 +29,9 @@ seo_description: 'The fundamentals of binary classification: key algorithms, eva
 seo_title: 'Binary Classification: Methods and Metrics'
 seo_type: article
 tags:
-- Binary classification
-- Supervised learning
-- Machine learning algorithms
+- Classification
+- Supervised Learning
+- Machine Learning
 title: 'Binary Classification: Explained'
 ---
 

--- a/_posts/2023-09-04-fears_surrounding_artificial_intelligence.md
+++ b/_posts/2023-09-04-fears_surrounding_artificial_intelligence.md
@@ -30,9 +30,9 @@ seo_title: The Fears and Challenges of AI and Automation
 seo_type: article
 subtitle: Automation and Machine Learning
 tags:
-- Data science
-- Artificial intelligence
-- Machine learning
+- Data Science
+- Artificial Intelligence
+- Machine Learning
 - Ethics
 title: The Fears Surrounding Artificial Intelligence
 ---

--- a/_posts/2023-09-08-dynamics_traffic_control_pedestrian_behavior.md
+++ b/_posts/2023-09-08-dynamics_traffic_control_pedestrian_behavior.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Science and Engineering
+- Research
 classes: wide
 date: '2023-09-08'
 excerpt: This article explores the complex interplay between traffic control, pedestrian
@@ -21,15 +21,14 @@ keywords:
 - Intelligent traffic systems
 - Mathematical models in traffic flow
 - Crowd management
+redirect_from:
+- '/science and engineering/dynamics_traffic_control_pedestrian_behavior/'
 seo_description: An in-depth analysis of how traffic control systems and pedestrian
   dynamics can be modeled using principles of fluid dynamics.
 seo_title: Traffic Control, Pedestrian Dynamics, and Fluid Dynamics
 seo_type: article
 tags:
-- Traffic control
-- Pedestrian dynamics
-- Fluid dynamics
-- Urban planning
+- Transportation
 title: Exploring the Dynamics of Traffic Control and Pedestrian Behavior Through the
   Lens of Fluid Dynamics
 ---

--- a/_posts/2023-09-20-rolling_windows_signal_processing.md
+++ b/_posts/2023-09-20-rolling_windows_signal_processing.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Signal Processing
+- Predictive Maintenance
 classes: wide
 date: '2023-09-20'
 excerpt: Explore the diverse applications of rolling windows in signal processing,
@@ -25,16 +25,17 @@ keywords:
 - Filtering techniques
 - Data smoothing
 - Python
+redirect_from:
+- '/signal processing/rolling_windows_signal_processing/'
 seo_description: Learn how rolling windows can be applied in signal processing for
   smoothing, feature extraction, and time-frequency analysis.
 seo_title: Unlock the Power of Rolling Windows in Signal Processing
 seo_type: article
 social_image: /assets/images/rollingwindow.png
 tags:
-- Rolling windows
-- Feature extraction
-- Signal smoothing
-- Time-frequency analysis
+- Time Series
+- Feature Engineering
+- Signal Processing
 - Python
 title: Rolling Windows in Signal Processing
 ---

--- a/_posts/2023-09-26-new_illiteracy_that’s_crippling_our_decisionmaking.md
+++ b/_posts/2023-09-26-new_illiteracy_that’s_crippling_our_decisionmaking.md
@@ -27,9 +27,7 @@ seo_description: How innumeracy, the inability to work with numbers, undermines 
 seo_title: 'Innumeracy: The New Illiteracy Crippling Decision-Making'
 seo_type: article
 tags:
-- Numeracy
-- Data literacy
-- Decision making
+- Business Intelligence
 title: The New Illiteracy That’s Crippling Our Decision-Making
 ---
 

--- a/_posts/2023-09-27-Data_communication.md
+++ b/_posts/2023-09-27-Data_communication.md
@@ -29,9 +29,8 @@ seo_description: The role of communication in data-driven work, and how to balan
 seo_title: 'Data and Communication: Orchestrating a Harmonious Future'
 seo_type: article
 tags:
-- Communication
-- Data analysis
-- Storytelling
+- Research Methodology
+- Data Analysis
 title: Data and Communication
 ---
 

--- a/_posts/2023-09-27-sample_size.md
+++ b/_posts/2023-09-27-sample_size.md
@@ -29,9 +29,9 @@ seo_title: The Myth and Reality of Sample Size in Statistical Analysis
 seo_type: article
 subtitle: A Nuanced Perspective
 tags:
-- Data analysis
-- Sample size
-- Statistical accuracy
+- Data Analysis
+- Sample Size
+- Model Evaluation
 title: The Myth and Reality of Sample Size in Statistical Analysis
 ---
 

--- a/_posts/2023-09-30-multiple_regression_vs_stepwise_regression.md
+++ b/_posts/2023-09-30-multiple_regression_vs_stepwise_regression.md
@@ -30,12 +30,11 @@ summary: Multiple regression and stepwise regression are powerful tools for pred
   in fields like business analytics and scientific research, helping you build effective
   models.
 tags:
-- Multiple regression
-- Stepwise regression
-- Predictive modeling
-- Business analytics
-- Scientific research
-- Bash
+- Regression
+- Machine Learning
+- Business Intelligence
+- Research Methodology
+- Programming
 - Python
 title: 'Multiple Regression vs. Stepwise Regression: Building the Best Predictive
   Models'

--- a/_posts/2023-10-01-coverage_probability.md
+++ b/_posts/2023-10-01-coverage_probability.md
@@ -27,9 +27,8 @@ summary: In statistical estimation theory, coverage probability measures the lik
   explains its importance in statistical theory, prediction intervals, and nominal
   coverage probability.
 tags:
-- Confidence intervals
-- Statistical theory
-- Estimation
+- Confidence Intervals
+- Statistical Modeling
 title: 'Coverage Probability: Explained'
 ---
 

--- a/_posts/2023-10-02-overview_natural_language_processing_data_science.md
+++ b/_posts/2023-10-02-overview_natural_language_processing_data_science.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Natural Language Processing
+- Machine Learning
 classes: wide
 date: '2023-10-02'
 excerpt: Natural Language Processing (NLP) is integral to data science, enabling tasks
@@ -23,6 +23,8 @@ keywords:
 - Spacy
 - Hugging face
 - Data science
+redirect_from:
+- '/natural language processing/overview_natural_language_processing_data_science/'
 seo_description: Explore how Natural Language Processing (NLP) fits into data science,
   common NLP tasks, popular libraries like NLTK and SpaCy, and real-world applications.
 seo_title: 'NLP in Data Science: Tasks, Tools, and Uses'
@@ -31,13 +33,9 @@ summary: This article provides an overview of Natural Language Processing (NLP) 
   data science, covering its role in the field, common NLP tasks, tools like NLTK
   and SpaCy, and real-world applications in various industries.
 tags:
-- Natural language processing (nlp)
-- Text classification
-- Sentiment analysis
-- Data science
-- Nltk
-- Spacy
-- Hugging face
+- Natural Language Processing
+- Classification
+- Data Science
 title: An Overview of Natural Language Processing in Data Science
 ---
 

--- a/_posts/2023-10-31-detecting_trends_timeseries_data.md
+++ b/_posts/2023-10-31-detecting_trends_timeseries_data.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time-Series Analysis
+- Time Series
 classes: wide
 date: '2023-10-31'
 excerpt: Learn how the Mann-Kendall Test is used for trend detection in time-series
@@ -23,6 +23,8 @@ keywords:
 - Climate research
 - Bash
 - Python
+redirect_from:
+- '/time-series analysis/detecting_trends_timeseries_data/'
 seo_description: Explore the Mann-Kendall Test for detecting trends in time-series
   data, with applications in environmental studies, hydrology, and climate research.
 seo_title: Mann-Kendall Test for Trend Detection
@@ -32,13 +34,9 @@ summary: The Mann-Kendall Test is a non-parametric method for detecting trends i
   formulation, and its application in environmental studies, hydrology, and climate
   research.
 tags:
-- Mann-kendall test
-- Trend detection
-- Time-series data
-- Environmental studies
-- Hydrology
-- Climate research
-- Bash
+- Time Series
+- Climate and Environment
+- Programming
 - Python
 title: 'Mann-Kendall Test: Detecting Trends in Time-Series Data'
 ---

--- a/_posts/2023-11-01-linear_vs_logistic_model.md
+++ b/_posts/2023-11-01-linear_vs_logistic_model.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Probability Modeling
+- Statistics
 classes: wide
 date: '2023-11-01'
 excerpt: Both linear and logistic models offer unique advantages depending on the
@@ -19,6 +19,8 @@ keywords:
 - Statistical modeling
 - Interpretability
 - Statistical estimation
+redirect_from:
+- '/probability modeling/linear_vs_logistic_model/'
 seo_description: A comprehensive guide to understanding the advantages and limitations
   of linear and logistic probability models in statistical analysis.
 seo_title: 'Linear vs. Logistic Probability Models: Which is Better?'
@@ -26,10 +28,9 @@ seo_type: article
 summary: This article explores the pros and cons of linear and logistic probability
   models, highlighting interpretability, computation, and when to use each.
 tags:
-- Linear probability model
-- Logistic regression
-- Statistical modeling
-- Interpretability
+- Probability
+- Regression
+- Statistical Modeling
 title: 'Linear vs. Logistic Probability Models: A Comparative Analysis'
 ---
 

--- a/_posts/2023-11-15-analyzing_relationship_between_continuous_binary_variables.md
+++ b/_posts/2023-11-15-analyzing_relationship_between_continuous_binary_variables.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Data Analysis
+- Data Science
 classes: wide
 date: '2023-11-15'
 excerpt: Learn the differences between biserial and point-biserial correlation methods,
@@ -20,6 +20,8 @@ keywords:
 - Educational testing
 - Psychology
 - Medical diagnostics
+redirect_from:
+- '/data analysis/analyzing_relationship_between_continuous_binary_variables/'
 seo_description: Biserial and point-biserial correlation for continuous and binary variables, with applications in educational testing, psychology, and diagnostics.
 seo_title: Biserial vs. Point-Biserial Correlation
 seo_type: article
@@ -28,13 +30,8 @@ summary: Biserial and point-biserial correlation methods are used to analyze rel
   these two correlation techniques and their practical applications in fields like
   educational testing, psychology, and medical diagnostics.
 tags:
-- Biserial correlation
-- Point-biserial correlation
-- Binary variables
-- Continuous variables
-- Educational testing
-- Psychology
-- Medical diagnostics
+- Correlation
+- Healthcare
 title: 'Biserial and Point-Biserial Correlation: Analyzing the Relationship Between
   Continuous and Binary Variables'
 ---

--- a/_posts/2023-11-16-mannwhitney_u_test_nonparametric_comparison_two_independent_samples.md
+++ b/_posts/2023-11-16-mannwhitney_u_test_nonparametric_comparison_two_independent_samples.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Non-Parametric Tests
+- Statistics
 classes: wide
 date: '2023-11-16'
 excerpt: Learn how the Mann-Whitney U Test is used to compare two independent samples
@@ -23,6 +23,8 @@ keywords:
 - Medicine
 - Bash
 - Python
+redirect_from:
+- '/non-parametric tests/mannwhitney_u_test_nonparametric_comparison_two_independent_samples/'
 seo_description: The Mann-Whitney U test, a non-parametric method for comparing two independent samples, with applications in psychology, medicine, and ecology.
 seo_title: 'Mann-Whitney U Test: Comparing Two Independent Samples'
 seo_type: article
@@ -30,12 +32,10 @@ summary: The Mann-Whitney U Test is a non-parametric method used to compare two 
   samples. This article explains the test's assumptions, mathematical foundations,
   and its applications in fields like psychology, medicine, and ecology.
 tags:
-- Mann-whitney u test
-- Non-parametric statistics
-- Two independent samples
-- Hypothesis testing
-- Data analysis
-- Bash
+- Hypothesis Testing
+- Nonparametric Methods
+- Data Analysis
+- Programming
 - Python
 title: 'Mann-Whitney U Test: Non-Parametric Comparison of Two Independent Samples'
 ---

--- a/_posts/2023-11-30-math_fundamentals.md
+++ b/_posts/2023-11-30-math_fundamentals.md
@@ -24,9 +24,8 @@ seo_description: The linear algebra, calculus, probability, and optimization tha
 seo_title: Why Mathematics Is the Foundation of AI
 seo_type: article
 tags:
-- Mathematics
-- Machine learning
-- Linear algebra
+- Mathematical Modeling
+- Machine Learning
 - Optimization
 title: Why Mathematics Is the Foundation of AI
 ---

--- a/_posts/2023-12-01-managing_data_science.md
+++ b/_posts/2023-12-01-managing_data_science.md
@@ -27,10 +27,7 @@ summary: This article explores why managing data science projects with the same 
   as engineering leads to failure, explaining how the unknown nature of data science
   solutions differs from engineering's structured approach.
 tags:
-- Data science
-- Engineering
-- Project management
-- Ai/ml
+- Data Science
 title: Why Managing Data Science Like Engineering Leads to Failure
 ---
 

--- a/_posts/2023-12-15-renewable_energy_optimization.md
+++ b/_posts/2023-12-15-renewable_energy_optimization.md
@@ -1,17 +1,13 @@
 ---
+redirect_from:
+- '/renewable energy/artificial intelligence/energy systems/renewable_energy_optimization/'
 title: "AI and Machine Learning in Renewable Energy Optimization: Transforming the Future of Clean Energy"
 categories:
-- Renewable Energy
-- Artificial Intelligence
-- Energy Systems
+- Environment
 tags:
-- AI
+- Artificial Intelligence
 - Machine Learning
-- Renewable Energy
-- Energy Forecasting
-- Smart Grid
-- Energy Storage
-- Clean Energy
+- Climate and Environment
 author_profile: false
 seo_title: AI and ML for Renewable Energy Systems
 seo_description: How AI and machine learning are reshaping renewable energy forecasting, grid management, and storage optimization for a clean energy future.

--- a/_posts/2023-12-17-data_science_carbon_footprint_reduction.md
+++ b/_posts/2023-12-17-data_science_carbon_footprint_reduction.md
@@ -1,17 +1,13 @@
 ---
+redirect_from:
+- '/data science/sustainability/carbon management/data_science_carbon_footprint_reduction/'
 title: "Data Science in Carbon Footprint Reduction: Leveraging Big Data and Machine Learning for Sustainable Operations"
 categories:
 - Data Science
-- Sustainability
-- Carbon Management
 tags:
-- carbon footprint
-- machine learning
-- big data
-- emissions reduction
-- sustainable operations
-- green technology
-- carbon intelligence
+- Climate and Environment
+- Machine Learning
+- Data Engineering
 author_profile: false
 seo_title: "How Data Science Reduces Carbon Footprints Across Industries"
 seo_description: How big data and machine learning enable carbon footprint reduction in transportation, manufacturing, and beyond.

--- a/_posts/2023-12-30-data_engineering_introduction.md
+++ b/_posts/2023-12-30-data_engineering_introduction.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Data Engineering
+- Programming
 classes: wide
 date: '2023-12-30'
 excerpt: This article explores the fundamentals of data engineering, including the
@@ -19,6 +19,8 @@ keywords:
 - Elt
 - Data science
 - Data pipelines
+redirect_from:
+- '/data engineering/data_engineering_introduction/'
 seo_description: An in-depth overview of Data Engineering, discussing the ETL and
   ELT processes, data pipelines, and the necessary skills for data engineers.
 seo_title: 'Data Engineering: Skills, ETL, and ELT'
@@ -27,10 +29,8 @@ summary: Data Engineering is critical for managing and processing large datasets
   Learn about the skills, processes like ETL and ELT, and how they fit into modern
   data workflows.
 tags:
-- Etl
-- Data pipelines
-- Elt
-- Big data
+- Data Engineering
+- MLOps
 title: 'Introduction to Data Engineering: Processes, Skills, and Tools'
 ---
 

--- a/_posts/2023-12-30-value_risk_expected_shortfall.md
+++ b/_posts/2023-12-30-value_risk_expected_shortfall.md
@@ -30,10 +30,8 @@ seo_description: Value at Risk (VaR) and Expected Shortfall (ES) compared as ris
 seo_title: 'VaR vs Expected Shortfall: A Data-Driven Analysis'
 seo_type: article
 tags:
-- Value at risk
-- Expected shortfall
-- Financial crisis
-- Risk models
+- Finance
+- Risk Management
 - Python
 title: 'Comparing Value at Risk (VaR) and Expected Shortfall (ES): A Data-Driven Analysis'
 ---

--- a/_posts/2024-01-01-mathematics_machine_learning.md
+++ b/_posts/2024-01-01-mathematics_machine_learning.md
@@ -34,10 +34,9 @@ seo_description: 'The mathematical foundations of machine learning: classificati
 seo_title: 'Mathematics of Machine Learning: Key Concepts and Methods'
 seo_type: article
 tags:
-- Machine learning
-- Mathematical models
+- Machine Learning
+- Mathematical Modeling
 - Statistics
-- Algorithms
 title: 'Mathematics of Machine Learning: A Comprehensive Exploration'
 ---
 

--- a/_posts/2024-01-02-text_preprocessing_techniques_nlp_data_science.md
+++ b/_posts/2024-01-02-text_preprocessing_techniques_nlp_data_science.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Natural Language Processing
+- Machine Learning
 classes: wide
 date: '2024-01-02'
 excerpt: Text preprocessing is a crucial step in NLP for transforming raw text into
@@ -21,6 +21,8 @@ keywords:
 - Stemming
 - Lemmatization
 - Text normalization
+redirect_from:
+- '/natural language processing/text_preprocessing_techniques_nlp_data_science/'
 seo_description: 'Essential text preprocessing for NLP: tokenization, stemming, lemmatization, stopword handling, and advanced cleaning with regex.'
 seo_title: 'NLP Text Preprocessing: Tokenization and Stemming'
 seo_type: article
@@ -30,12 +32,7 @@ summary: This article provides an in-depth look at text preprocessing techniques
   advanced cleaning techniques such as regex for handling misspellings, slang, and
   abbreviations.
 tags:
-- Text preprocessing
-- Tokenization
-- Stemming
-- Lemmatization
-- Nlp techniques
-- Text normalization
+- Natural Language Processing
 title: Text Preprocessing Techniques for NLP in Data Science
 ---
 

--- a/_posts/2024-01-28-normal_distribution.md
+++ b/_posts/2024-01-28-normal_distribution.md
@@ -30,12 +30,10 @@ seo_title: 'The Bell Curve: Understanding Normal Distribution'
 seo_type: article
 subtitle: The Normal Distribution
 tags:
-- Data science
-- Mathematical modeling
-- Statistical methods
-- Machine learning
-- Statistical analysis
-- Bell curve
+- Data Science
+- Mathematical Modeling
+- Statistical Modeling
+- Machine Learning
 - Python
 title: A Closer Look at the Classic Bell Curve
 ---

--- a/_posts/2024-01-29-probabilistic_programming.md
+++ b/_posts/2024-01-29-probabilistic_programming.md
@@ -31,15 +31,12 @@ seo_title: 'Demystifying MCMC: A Hands-On Guide to Bayesian Inference'
 seo_type: article
 subtitle: Understanding the Metropolis Algorithm Through Code
 tags:
-- Data science
-- Mathematical modeling
-- Statistical methods
-- Machine learning
-- Statistical analysis
+- Data Science
+- Mathematical Modeling
+- Statistical Modeling
+- Machine Learning
 - Probability
-- Probabilistic programming
-- Bayesian statistics
-- Python
+- Programming
 title: 'Demystifying MCMC: A Practical Guide to Bayesian Inference'
 ---
 

--- a/_posts/2024-01-30-Monte_Carlo.md
+++ b/_posts/2024-01-30-Monte_Carlo.md
@@ -26,15 +26,12 @@ subtitle: Complex Probabilities with Markov Chain Monte Carlo
 summary: A comprehensive guide to understanding Bayesian statistics and MCMC methods,
   including real-world applications and Python examples.
 tags:
-- Bayesian statistics
-- Markov chain monte carlo (mcmc)
-- Statistical computing
-- Data analysis techniques
-- Probability theory
-- Python programming for statistics
-- Predictive modeling
-- Machine learning algorithms
+- Bayesian Statistics
+- Stochastic Processes
+- Data Analysis
+- Probability
 - Python
+- Machine Learning
 title: 'Mastering Bayesian Statistics: An In-Depth Guide to MCMC'
 ---
 

--- a/_posts/2024-02-01-customer_life_value.md
+++ b/_posts/2024-02-01-customer_life_value.md
@@ -31,15 +31,9 @@ seo_title: Customer Lifetime Value and Business Growth
 seo_type: article
 subtitle: A Key Metric for Business Growth
 tags:
-- Clv
-- Business strategy
-- Customer retention
-- Marketing analytics
-- Customer acquisition
-- Data analytics
-- Crm (customer relationship management)
-- Business growth
-- Loyalty programs
+- Customer Analytics
+- Business Intelligence
+- Data Analysis
 - Python
 title: Understanding Customer Lifetime Value
 toc: false

--- a/_posts/2024-02-02-topology_data_science.md
+++ b/_posts/2024-02-02-topology_data_science.md
@@ -31,18 +31,12 @@ seo_type: article
 subtitle: Exploring Topological Data Analysis and Its Impact on Uncovering Hidden
   Insights in Complex Data Sets
 tags:
-- Topological data analysis (tda)
-- Data science
-- Machine learning
-- Persistent homology
-- Mapper algorithm
-- High-dimensional data
-- Big data analytics
-- Network analysis
-- Anomaly detection
-- Computational topology
-- Mathematical foundations of data science
-- Interdisciplinary approaches in data analysis
+- Data Science
+- Machine Learning
+- Data Analysis
+- Data Engineering
+- Graph Theory
+- Anomaly Detection
 title: Convergence of Topology and Data Science
 toc: false
 toc_label: The Complexity of Real-World Data Distributions

--- a/_posts/2024-02-08-realworld_data_distributions.md
+++ b/_posts/2024-02-08-realworld_data_distributions.md
@@ -30,16 +30,10 @@ seo_title: 'Clustering Explained: How Algorithms Group Data'
 seo_type: article
 subtitle: A Dive into Data's Inner Circles
 tags:
-- Data science
-- Machine learning
-- Clustering algorithms
-- K-means clustering
-- Hierarchical clustering
-- Dbscan
-- Spectral clustering
-- Data analysis
-- Pattern recognition
-- Bioinformatics
+- Data Science
+- Machine Learning
+- Clustering
+- Data Analysis
 title: Mysteries of Clustering
 toc: false
 toc_label: The Complexity of Real-World Data Distributions

--- a/_posts/2024-02-09-spectral_clustering.md
+++ b/_posts/2024-02-09-spectral_clustering.md
@@ -27,12 +27,10 @@ seo_title: Spectral Clustering and Dimensionality Reduction
 seo_type: article
 subtitle: A Comprehensive Guide to Spectral Clustering
 tags:
-- Data science
-- Machine learning
-- Clustering algorithms
-- Spectral clustering
-- Data analysis
-- Pattern recognition
+- Data Science
+- Machine Learning
+- Clustering
+- Data Analysis
 title: The Power of Dimensionality Reduction
 toc: false
 toc_label: The Complexity of Real-World Data Distributions

--- a/_posts/2024-02-10-pingenhole_principle.md
+++ b/_posts/2024-02-10-pingenhole_principle.md
@@ -37,15 +37,10 @@ summary: This article delves into the Pigeonhole Principle, illustrating its pro
   simplicity and exploring its applications in various mathematical fields such as
   combinatorics, number theory, geometry, and data compression.
 tags:
-- Pigeonhole principle
-- Mathematical logic
 - Combinatorics
-- Data compression
+- Mathematical Modeling
 - Geometry
-- Number theory
-- Rubik's cube
-- Rational numbers
-- Mathematical proofs
+- Number Theory
 - R
 - Python
 title: 'Elegance of the Pigeonhole Principle: A Mathematical Odyssey'

--- a/_posts/2024-02-11-Ergodicity.md
+++ b/_posts/2024-02-11-Ergodicity.md
@@ -31,17 +31,12 @@ seo_title: Ergodicity in Statistical and Mathematical Models
 seo_type: article
 subtitle: Clarifying Ergodicity
 tags:
-- Ergodicity
-- Bernoulli trials
-- Python programming
-- Statistical analysis
-- Data science
-- Statistical physics
-- Mathematical modeling
-- Simulation and modeling
-- Computational physics
-- Machine learning
 - Python
+- Statistical Modeling
+- Data Science
+- Mathematical Modeling
+- Monte Carlo
+- Machine Learning
 title: Distinguishing Ergodic Regimes from Processes
 toc: false
 toc_label: The Complexity of Real-World Data Distributions

--- a/_posts/2024-02-11-combinatorics_python.md
+++ b/_posts/2024-02-11-combinatorics_python.md
@@ -32,17 +32,11 @@ seo_title: 'Mastering Combinatorics with Python: A Practical Guide'
 seo_type: article
 subtitle: A Practical Guide
 tags:
-- Python programming
-- Combinatorial mathematics
-- Itertools library
-- Scientific computing
-- Probability theory
-- Mathematical software
-- Data analysis techniques
-- Algorithm development
-- Computational mathematics
-- Python libraries
 - Python
+- Mathematical Modeling
+- Probability
+- Data Analysis
+- Machine Learning
 - R
 title: Mastering Combinatorics with Python
 toc: false

--- a/_posts/2024-02-12-combinatorics_probability.md
+++ b/_posts/2024-02-12-combinatorics_probability.md
@@ -32,14 +32,11 @@ summary: This article explores the intersection of combinatorics and probability
   uncovering how their mathematical synergies solve complex problems in data science,
   mathematics, and beyond.
 tags:
-- Mathematics
+- Mathematical Modeling
 - Combinatorics
-- Probability theory
-- Statistical analysis
-- Mathematical foundations
-- Data science
-- Educational resources
-- Mathematical applications
+- Probability
+- Statistical Modeling
+- Data Science
 title: Paths of Combinatorics and Probability
 toc: false
 toc_label: The Complexity of Real-World Data Distributions

--- a/_posts/2024-02-12-ethical_considerations_elderly_care.md
+++ b/_posts/2024-02-12-ethical_considerations_elderly_care.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- HealthTech
+- Data Science
 classes: wide
 date: '2024-02-12'
 excerpt: As AI revolutionizes elderly care, ethical concerns around privacy, autonomy,
@@ -20,6 +20,8 @@ keywords:
 - Big data privacy
 - Elderly autonomy
 - Informed consent
+redirect_from:
+- '/healthtech/ethical_considerations_elderly_care/'
 seo_description: This article explores the ethical challenges of using AI, big data,
   and machine learning in elderly care, focusing on privacy, autonomy, and informed
   consent.
@@ -31,10 +33,8 @@ summary: The integration of AI and machine learning in elderly care promises sig
   care systems, offering strategies to balance innovation with the dignity of elderly
   individuals.
 tags:
-- Ai in healthcare
-- Elderly care
-- Ethical ai
-- Privacy
+- Healthcare
+- Ethics
 title: Ethical Considerations in AI-Powered Elderly Care
 ---
 

--- a/_posts/2024-02-14-advanced_sequential_changepoint.md
+++ b/_posts/2024-02-14-advanced_sequential_changepoint.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Data Analysis
+- Data Science
 classes: wide
 date: '2024-02-14'
 excerpt: Sequential change-point detection plays a crucial role in real-time monitoring
@@ -26,13 +26,14 @@ keywords:
 - Sequential change-point algorithms
 - Time series analysis
 - Python
+redirect_from:
+- '/data analysis/advanced_sequential_changepoint/'
 seo_description: Advanced methods for sequential change-point detection in univariate models, covering theory, applications, and key statistical techniques.
 seo_title: Sequential Change-Point Detection Techniques
 seo_type: article
 tags:
-- Change-point detection
-- Univariate models
-- Sequential analysis
+- Data Drift
+- Experimental Design
 - Python
 title: Advanced Sequential Change-Point Detection for Univariate Models
 ---

--- a/_posts/2024-02-17-climate_var.md
+++ b/_posts/2024-02-17-climate_var.md
@@ -29,10 +29,9 @@ seo_description: Climate Value at Risk (VaR) from a data science perspective, an
 seo_title: 'Climate VaR: Data Science and Financial Risk Assessment'
 seo_type: article
 tags:
-- Climate change
-- Value at risk
-- Data science
-- Financial risk management
+- Climate and Environment
+- Finance
+- Data Science
 - Python
 title: 'Climate Value at Risk (VaR): A Data Science Perspective'
 ---

--- a/_posts/2024-03-07-AI_history.md
+++ b/_posts/2024-03-07-AI_history.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Technology
+- Research
 classes: wide
 date: '2024-03-07'
 header:
@@ -12,13 +12,13 @@ header:
   teaser: /assets/images/data_science_5.jpg
   twitter_image: /assets/images/data_science_6.jpg
 keywords: []
+redirect_from:
+- '/technology/AI_history/'
 seo_description: 'How artificial intelligence developed, from ancient myths and mechanical automata to the algorithms behind today''s assistants and systems.'
 seo_title: The History of Artificial Intelligence
 seo_type: article
 tags:
-- Artificial intelligence
-- Ai
-- Technology history
+- Artificial Intelligence
 title: The History of Artificial Intelligence
 ---
 

--- a/_posts/2024-05-09-kernel_clustering_r.md
+++ b/_posts/2024-05-09-kernel_clustering_r.md
@@ -16,28 +16,12 @@ seo_title: 'Kernel Clustering in R: A Practical Guide'
 seo_type: article
 subtitle: A Practical Guide to Advanced Data Segmentation
 tags:
-- Kernel clustering in r
-- Advanced data clustering techniques
-- Non-linear data analysis
-- Machine learning in r
-- Kernlab package
-- Gaussian kernel clustering
-- R data science tools
-- Support vector clustering
-- Multidimensional data analysis
-- Kernel methods for clustering
-- Clustering non-linear data
-- Data mining in r
-- Statistical learning in r
-- Cluster analysis methods
-- Radial basis function (rbf)
-- Data segmentation techniques
-- Unsupervised learning in r
-- Pattern recognition with kernels
-- K-means kernel clustering
-- Scalable clustering algorithms in r
-- Unknown
-- R
+- Clustering
+- Data Analysis
+- Machine Learning
+- Data Science
+- Customer Analytics
+- Unsupervised Learning
 title: Kernel Clustering in R
 ---
 

--- a/_posts/2024-05-09-understanding_tsne.md
+++ b/_posts/2024-05-09-understanding_tsne.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Machine Learning
 classes: wide
 date: '2024-05-09'
 header:
@@ -13,32 +11,19 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_3.jpg
   twitter_image: /assets/images/data_science_3.jpg
+redirect_from:
+- '/mathematics/statistics/machine learning/understanding_tsne/'
 seo_description: How t-SNE reduces high-dimensional data for visualization, covering parameter tuning and how to interpret the results.
 seo_title: Understanding t-SNE for Dimensionality Reduction
 seo_type: article
 subtitle: A Guide to Visualizing High-Dimensional Data
 tags:
-- T-sne
-- Dimensionality reduction
-- High-dimensional data visualization
-- Machine learning techniques
-- Data science
-- Stochastic neighbor embedding
-- Visualizing complex data
-- T-sne algorithms
-- Bioinformatics visualization
-- Multidimensional scaling
-- Feature extraction
-- Big data analytics
-- T-sne in python
-- T-sne in r
-- Unsupervised learning
-- Artificial intelligence
-- Clustering high-dimensional data
-- Neural network visualization
-- Genomics data analysis
-- Interactive data visualization
-- Python
+- Dimensionality Reduction
+- Data Visualization
+- Machine Learning
+- Data Science
+- Probability
+- Feature Engineering
 title: Understanding t-SNE
 ---
 

--- a/_posts/2024-05-10-data_analysis_gdp.md
+++ b/_posts/2024-05-10-data_analysis_gdp.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Economy
 classes: wide
 date: '2024-05-10'
 header:
@@ -14,21 +11,17 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_4.jpg
   twitter_image: /assets/images/data_science_1.jpg
+redirect_from:
+- '/mathematics/statistics/data science/economy/data_analysis_gdp/'
 seo_description: Why aggregated GDP figures mislead data science analysis, from measurement and timeliness problems to the dimensions GDP never captures.
 seo_title: Limitations of Aggregated GDP Data
 seo_type: article
 subtitle: Exploring the Shortcomings of GDP as a Sole Economic Indicator in Data Science
   Applications
 tags:
-- Gdp limitations
-- Economic analysis
-- Data aggregation
-- Real-time data
-- Economic indicators
-- Data quality
-- Comparative analysis
-- Alternative metrics
-- Data analysis
+- Economics
+- Data Quality
+- Data Analysis
 title: The Limitations of Aggregated GDP Data in Data Science Analysis
 ---
 

--- a/_posts/2024-05-10-stratified_sampling.md
+++ b/_posts/2024-05-10-stratified_sampling.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
 classes: wide
 date: '2024-05-10'
 header:
@@ -13,27 +11,16 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_9.jpg
   twitter_image: /assets/images/data_science_9.jpg
+redirect_from:
+- '/mathematics/statistics/data science/stratified_sampling/'
 seo_description: How stratified sampling improves representativeness and accuracy by dividing a population into subgroups before sampling.
 seo_title: 'Stratified Sampling: Methods and Applications'
 seo_type: article
 subtitle: A Key to Representative Research
 tags:
-- Stratified sampling
-- Statistical methods
-- Sampling bias
-- Representative sampling
-- Population strata
-- Random sampling
-- Cluster sampling
-- Research accuracy
-- Data collection efficiency
-- Methodological challenges
-- Statistical analysis
-- Comparative study
-- Sample size determination
-- Data representativeness
-- Survey methodology
-- Field applications
+- Statistical Modeling
+- Model Evaluation
+- Sample Size
 title: Stratified Sampling
 ---
 

--- a/_posts/2024-05-10-survival_analysis.md
+++ b/_posts/2024-05-10-survival_analysis.md
@@ -36,21 +36,9 @@ summary: This article examines survival analysis in management, detailing its ke
   concepts like hazard and survival functions, censoring, and applications such as
   employee retention, customer churn, and product lifespan modeling.
 tags:
-- Survival analysis
-- Time-to-event data
-- Censoring and truncation
-- Hazard function
-- Survival function
-- Kaplan-meier estimator
-- Cox proportional hazards model
-- Employee retention
-- Customer churn
-- Product lifespan
-- Management decision-making
-- Statistical modeling in management
-- Data-driven decision-making
-- Business analytics
-- Data-driven management
+- Survival Analysis
+- Customer Analytics
+- Business Intelligence
 - R
 - Python
 title: Survival Analysis in Management

--- a/_posts/2024-05-11-Importance_Sampling.md
+++ b/_posts/2024-05-11-Importance_Sampling.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
 classes: wide
 date: '2024-05-11'
 header:
@@ -13,27 +11,19 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_3.jpg
   twitter_image: /assets/images/data_science_9.jpg
+redirect_from:
+- '/mathematics/statistics/data science/Importance_Sampling/'
 seo_description: How importance sampling improves the efficiency and accuracy of simulations by focusing on the most significant probability regions.
 seo_title: Importance Sampling in Research
 seo_type: article
 subtitle: Impact of Importance Sampling on Simulation Accuracy and Computational Economy
 tags:
-- Importance sampling
-- Statistical simulations
-- Variance reduction
-- Computational efficiency
-- Rare event simulation
-- Probability distributions
-- Financial risk modeling
-- Machine learning algorithms
-- Engineering reliability
-- Advanced sampling techniques
-- Monte carlo methods
-- Research methodologies
-- Efficiency in data analysis
-- Climate modeling
-- Epidemiological studies
-- Machine learning methods
+- Monte Carlo
+- Descriptive Statistics
+- Probability
+- Finance
+- Machine Learning
+- Research Methodology
 title: 'Efficiency in Research: The Strategic Role of Importance Sampling'
 ---
 

--- a/_posts/2024-05-14-Kullback.md
+++ b/_posts/2024-05-14-Kullback.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Machine Learning
 classes: wide
 date: '2024-05-14'
 header:
@@ -14,33 +11,19 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_8.jpg
   twitter_image: /assets/images/data_science_7.jpg
+redirect_from:
+- '/mathematics/statistics/data science/machine learning/Kullback/'
 seo_description: 'Kullback-Leibler divergence and Wasserstein distance compared: how each measures the difference between probability distributions.'
 seo_title: Kullback-Leibler and Wasserstein Distances
 seo_type: article
 subtitle: Measuring Differences Between Distributions
 tags:
-- Kullback-leibler divergence
-- Kl divergence
-- Wasserstein distance
-- Probability distributions
-- Euclidean distance
-- Optimal transport
-- Information theory
-- Machine learning
-- Computer vision
-- Data science
-- Statistical measures
-- Distance metrics
-- Probability mass
-- Cumulative distribution function (cdf)
-- Python code examples
-- Asymmetry in kl divergence
-- Finance and insurance
-- Mathematical finance
-- Statistical analysis
-- Probability theory
-- Data analysis
-- Python
+- Information Theory
+- Probability
+- Machine Learning
+- Data Science
+- Descriptive Statistics
+- Mathematical Modeling
 title: Kullback-Leibler and Wasserstein Distances
 ---
 

--- a/_posts/2024-05-14-P_value.md
+++ b/_posts/2024-05-14-P_value.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
 classes: wide
 date: '2024-05-14'
 header:
@@ -13,22 +11,17 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_8.jpg
   twitter_image: /assets/images/data_science_2.jpg
+redirect_from:
+- '/mathematics/statistics/data science/P_value/'
 seo_description: What p-values and probability distributions really mean in hypothesis testing, with visual and Python-based explanations.
 seo_title: 'From Data to Probability: P-Values Explained'
 seo_type: article
 subtitle: A Step-by-Step Guide to Understanding and Calculating the P Value in Statistical
   Analysis
 tags:
-- P value
-- Probability distribution
-- Statistical significance
-- Null hypothesis
-- Test statistic
-- Normal distribution
-- T-distribution
-- Central limit theorem
-- Biostatistics
-- Statistical analysis
+- Hypothesis Testing
+- Probability
+- Statistical Modeling
 - Python
 title: From Data to Probability
 ---

--- a/_posts/2024-05-15-AI_fairness.md
+++ b/_posts/2024-05-15-AI_fairness.md
@@ -2,10 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Machine Learning
-- Ethics Research
 classes: wide
 date: '2024-05-15'
 header:
@@ -15,31 +11,15 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_8.jpg
   twitter_image: /assets/images/data_science_3.jpg
+redirect_from:
+- '/mathematics/statistics/data science/machine learning/ethics research/AI_fairness/'
 seo_description: 'AI fairness explained: how to measure it, where bias comes from, and the strategies used to mitigate unfairness in machine learning.'
 seo_title: 'Navigating AI Fairness: Metrics and Mitigation'
 seo_type: article
 subtitle: Challenges, Metrics, and Mitigation Techniques
 tags:
-- Ai fairness
-- Bias in ai
-- Machine learning fairness
-- Demographic parity
-- Equal opportunity
-- Statistical parity
-- Consistency in ai
-- Individual fairness
-- Counterfactual fairness
-- Unbiased ai
-- Fairness through unawareness
-- Transparency in ai
-- Ai ethics
-- Bias mitigation techniques
-- Adversarial learning
-- Data collection bias
-- Fairness metrics
-- Ai fairness libraries
-- Fairness in machine learning
-- Ai discrimination
+- Ethics
+- Machine Learning
 title: Navigating AI Fairness
 ---
 

--- a/_posts/2024-05-15-Feature_Engineering.md
+++ b/_posts/2024-05-15-Feature_Engineering.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Machine Learning
 classes: wide
 date: '2024-05-15'
 header:
@@ -14,24 +11,19 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_2.jpg
   twitter_image: /assets/images/data_science_3.jpg
+redirect_from:
+- '/mathematics/statistics/data science/machine learning/Feature_Engineering/'
 seo_description: How automated feature engineering creates and selects variables that improve model accuracy and reduce overfitting.
 seo_title: Automating Feature Engineering
 seo_type: article
 subtitle: Featuretools and TPOT for Efficient and Effective Feature Engineering
 tags:
-- Feature engineering
-- Machine learning
-- Data science
-- Automation tools
-- Featuretools
-- Tpot
-- Data cleaning
-- Data transformation
-- Feature creation
-- Feature selection
-- Genetic algorithms
-- Model optimization
-- Python
+- Feature Engineering
+- Machine Learning
+- Data Science
+- MLOps
+- Data Quality
+- Optimization
 title: Automating Feature Engineering
 ---
 

--- a/_posts/2024-05-15-detect_multivariate_data_drift.md
+++ b/_posts/2024-05-15-detect_multivariate_data_drift.md
@@ -37,19 +37,12 @@ summary: A detailed guide on detecting multivariate data drift using Principal C
   Analysis (PCA) and Reconstruction Error to monitor changes in data structure and
   ensure model performance in production environments.
 tags:
-- Multivariate data drift
-- Principal component analysis (pca)
-- Reconstruction error
-- Data monitoring
-- Machine learning model validation
-- Feature space analysis
-- Dimensionality reduction
-- Model performance
-- Mathematics
+- Multivariate Analysis
+- Dimensionality Reduction
+- Model Monitoring
+- Mathematical Modeling
 - Statistics
-- Data science
-- Production data
-- Python
+- Data Science
 title: Detect Multivariate Data Drift
 ---
 

--- a/_posts/2024-05-16-regularization_machine_learning.md
+++ b/_posts/2024-05-16-regularization_machine_learning.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Machine Learning
 classes: wide
 date: '2024-05-16'
 header:
@@ -14,21 +11,18 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_3.jpg
   twitter_image: /assets/images/data_science_3.jpg
+redirect_from:
+- '/mathematics/statistics/data science/machine learning/regularization_machine_learning/'
 seo_description: How regularization prevents overfitting in machine learning, why it works, and how the main techniques compare.
 seo_title: Regularization in Machine Learning
 seo_type: article
 subtitle: Techniques to Prevent Overfitting and Improve Model Performance
 tags:
 - Regularization
-- Overfitting
-- L1 regularization
-- L2 regularization
-- Elastic net
-- Machine learning
-- Model generalization
-- Feature selection
-- Model interpretability
-- High-dimensional data
+- Regression
+- Machine Learning
+- Feature Engineering
+- Data Analysis
 title: Regularization in Machine Learning
 ---
 

--- a/_posts/2024-05-17-Markov_Chain.md
+++ b/_posts/2024-05-17-Markov_Chain.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Machine Learning
 classes: wide
 date: '2024-05-17'
 header:
@@ -22,6 +19,8 @@ keywords:
 - Parking lot occupancy
 - Predictive modeling
 - Markov chains
+redirect_from:
+- '/mathematics/statistics/data science/machine learning/Markov_Chain/'
 seo_description: Markov chains and Hidden Markov Models explained, with real-world applications such as parking lot occupancy prediction.
 seo_title: 'Markov Systems: Foundations and Applications'
 seo_type: article
@@ -31,14 +30,7 @@ summary: This article explores the foundations and real-world applications of Ma
   systems, including Markov chains and Hidden Markov Models, in areas such as parking
   lot occupancy prediction.
 tags:
-- Markov systems
-- Markov chains
-- Hidden markov models
-- Stochastic processes
-- Andrey markov
-- Claude shannon
-- Real-world applications
-- Parking lot occupancy
+- Stochastic Processes
 title: Understanding Markov Systems
 ---
 

--- a/_posts/2024-05-19-Bhattacharyya_Distance.md
+++ b/_posts/2024-05-19-Bhattacharyya_Distance.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Machine Learning
 classes: wide
 date: '2024-05-19'
 excerpt: Dive into Bhattacharyya distance, loss functions such as MSE and cross-entropy,
@@ -24,6 +21,8 @@ keywords:
 - Machine learning optimization
 - Kl divergence vs bhattacharyya distance
 - Loss functions in regression and classification
+redirect_from:
+- '/mathematics/statistics/data science/machine learning/Bhattacharyya_Distance/'
 seo_description: Bhattacharyya distance and loss functions such as MSE and cross-entropy, and how they optimize regression and classification models.
 seo_title: Bhattacharyya Distance and Loss Functions
 seo_type: article
@@ -32,19 +31,12 @@ summary: This article covers key similarity measures like Bhattacharyya distance
   explores essential loss functions such as mean squared error and cross-entropy,
   which are crucial for optimizing machine learning models.
 tags:
-- Bhattacharyya distance
-- Probability distributions
-- Kl divergence
-- Loss functions
+- Information Theory
+- Probability
+- Model Evaluation
 - Regression
 - Classification
-- Mean squared error
-- Cross-entropy loss
-- Machine learning optimization
-- Mathematics
-- Statistics
-- Data science
-- Machine learning
+- Machine Learning
 title: Similarity Measures and Loss Functions in Machine Learning
 ---
 

--- a/_posts/2024-05-19-gini_coefficiente.md
+++ b/_posts/2024-05-19-gini_coefficiente.md
@@ -31,27 +31,12 @@ summary: This article explores the Normalized Gini Coefficient and Default Rate,
   metrics used in credit scoring and risk assessment. Learn how these metrics are
   applied in machine learning and financial modeling.
 tags:
-- Gini coefficient
-- Default rate
-- Normalized gini coefficient
-- Credit risk
-- Economic indicators
-- Machine learning metrics
-- Model evaluation
-- Loss functions
-- Credit scoring
-- Risk assessment
-- Loan default
-- Credit scorecard
-- Behavior scorecard
-- Area under roc curve (auc)
-- Tensorflow implementation
-- Loan risk analysis
+- Economics
+- Finance
+- Model Evaluation
+- Risk Management
 - Python
-- Mathematics
-- Statistics
-- Data science
-- Machine learning
+- Mathematical Modeling
 title: Understanding the Normalized Gini Coefficient and Default Rate
 ---
 

--- a/_posts/2024-05-20-probability_odds.md
+++ b/_posts/2024-05-20-probability_odds.md
@@ -29,14 +29,11 @@ summary: This article provides a detailed explanation of probability and odds, e
   and machine learning.
 tags:
 - Probability
-- Odds
-- Likelihood
-- Biostatistics
-- Event occurrence
-- Mathematics
+- Statistical Modeling
+- Mathematical Modeling
 - Statistics
-- Data science
-- Machine learning
+- Data Science
+- Machine Learning
 title: Understanding Probability and Odds
 ---
 

--- a/_posts/2024-05-21-Probability_integral_transform.md
+++ b/_posts/2024-05-21-Probability_integral_transform.md
@@ -34,21 +34,12 @@ summary: This article explains the Probability Integral Transform, its role in s
   modeling, and how it is applied in diverse fields like risk management, hypothesis
   testing, and Monte Carlo simulations.
 tags:
-- Probability integral transform
-- Cumulative distribution function
-- Uniform distribution
-- Copula construction
-- Goodness of fit
-- Monte carlo simulations
-- Hypothesis testing
-- Marketing mix modeling
-- Credit risk modeling
-- Financial risk management
+- Probability
+- Hypothesis Testing
+- Monte Carlo
+- Customer Analytics
+- Finance
 - R
-- Mathematics
-- Statistics
-- Data science
-- Machine learning
 title: 'Probability Integral Transform: Theory and Applications'
 ---
 

--- a/_posts/2024-05-22-Peer_review.md
+++ b/_posts/2024-05-22-Peer_review.md
@@ -1,13 +1,7 @@
 ---
 author_profile: false
 categories:
-- Academic Writing
-- Research Methodology
-- Political Communication
-- Social Media Studies
-- Digital Democracy
-- Social Network Analysis
-- Political Sociology
+- Data Science
 classes: wide
 date: '2024-05-22'
 header:
@@ -17,22 +11,15 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_9.jpg
   twitter_image: /assets/images/data_science_1.jpg
+redirect_from:
+- '/academic writing/research methodology/political communication/social media studies/digital democracy/social network analysis/political sociology/Peer_review/'
 seo_description: A critical review of a study on filter bubbles and MP interactions on Twitter, covering its limitations and research directions.
 seo_title: 'Review: Filter Bubbles Among MPs on Twitter'
 seo_type: article
 tags:
-- Twitter
-- Members of parliament (mps)
-- Political interaction
-- Filter bubbles
-- Echo chambers
-- Social network analysis
-- Political communication
-- Digital engagement
-- Homophily
-- Status homophily
-- Online political behavior
-- Social media analysis
+- Signal Processing
+- Graph Theory
+- Research Methodology
 title: 'Critical Review of ''Bursting the (Filter) Bubble: Interactions of Members
   of Parliament on Twitter'''
 ---

--- a/_posts/2024-05-22-how_write_research_paper.md
+++ b/_posts/2024-05-22-how_write_research_paper.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Research Methodology
+- Data Science
 classes: wide
 date: '2024-05-22'
 excerpt: Master the process of writing a research paper with tips on developing a
@@ -23,6 +23,8 @@ keywords:
 - Proofreading techniques
 - Thesis development
 - Structuring research papers
+redirect_from:
+- '/research methodology/how_write_research_paper/'
 seo_description: 'How to write a research paper: thesis development, organizing notes, formatting citations, and proofreading techniques.'
 seo_title: 'How to Write a Research Paper: Tips for Academic Writing'
 seo_type: article
@@ -30,26 +32,7 @@ summary: This guide provides essential tips for writing a research paper, from o
   and drafting to editing and revising, with insights on thesis statements, literature
   reviews, and formatting citations.
 tags:
-- Research paper writing
-- Academic writing tips
-- Thesis statement development
-- Research methodology
-- Literature review process
-- Writing an outline
-- Drafting a research paper
-- Editing and revising papers
-- Proofreading techniques
-- Formatting academic papers
-- Citation styles (apa, mla, chicago)
-- In-depth research
-- Organizing research notes
-- Academic research tips
-- Effective writing strategies
-- Managing research projects
-- Structuring research papers
-- Finalizing research documents
-- Research paper guidelines
-- Academic paper structure
+- Research Methodology
 title: How to Write a Research Paper
 ---
 

--- a/_posts/2024-06-02-explain_nurse.md
+++ b/_posts/2024-06-02-explain_nurse.md
@@ -1,11 +1,7 @@
 ---
 author_profile: false
 categories:
-- Healthcare Education
-- Statistical Methods
-- Data Interpretation
-- Nursing Practice
-- Professional Development
+- Research
 classes: wide
 date: '2024-06-02'
 header:
@@ -15,18 +11,16 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_8.jpg
   twitter_image: /assets/images/data_science_8.jpg
+redirect_from:
+- '/healthcare education/statistical methods/data interpretation/nursing practice/professional development/explain_nurse/'
 seo_description: How weighted moving averages and standard deviation work in health care, explained for nurses and clinical decision-making.
 seo_title: Weighted Moving Average in Health Care
 seo_type: article
 tags:
-- Nursing education
-- Statistical analysis
-- Data interpretation in healthcare
-- Weighted moving average
-- Standard deviation
-- Clinical data
-- Nursing practice
-- Professional skills
+- Healthcare
+- Statistical Modeling
+- Time Series
+- Descriptive Statistics
 title: Explaining Weighted Moving Average and Standard Deviation in Health Care
 ---
 

--- a/_posts/2024-06-03-gtest_vs_chisquare_test.md
+++ b/_posts/2024-06-03-gtest_vs_chisquare_test.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Categorical Data Analysis
 classes: wide
 date: '2024-06-03'
 excerpt: Learn the key differences between the G-Test and Chi-Square Test for analyzing
@@ -22,6 +21,8 @@ keywords:
 - Genetic studies
 - Market research
 - Large datasets
+redirect_from:
+- '/statistics/categorical data analysis/gtest_vs_chisquare_test/'
 seo_description: The G-Test and Chi-Square Test compared for categorical data, with use cases in genetics, market research, and large datasets.
 seo_title: G-Test vs. Chi-Square Test for Categorical Data
 seo_type: article
@@ -29,12 +30,8 @@ summary: The G-Test and Chi-Square Test are two widely used statistical methods 
   analyzing categorical data. This article compares their formulas, assumptions, advantages,
   and applications in fields like genetic studies, market research, and large datasets.
 tags:
-- G-test
-- Chi-square test
-- Categorical data
-- Genetic studies
-- Market research
-- Large datasets
+- Hypothesis Testing
+- Data Analysis
 title: 'G-Test vs. Chi-Square Test: Modern Alternatives for Testing Categorical Data'
 ---
 

--- a/_posts/2024-06-04-poisson_distribution.md
+++ b/_posts/2024-06-04-poisson_distribution.md
@@ -2,10 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Statistics
-- R Programming
-- Probability and Statistics
-- Data Analysis
 classes: wide
 date: '2024-06-04'
 header:
@@ -15,21 +11,18 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_1.jpg
   twitter_image: /assets/images/data_science_7.jpg
+redirect_from:
+- '/data science/statistics/r programming/probability and statistics/data analysis/poisson_distribution/'
 seo_description: How to model count events with the Poisson distribution in R, from data preparation to fitting and assessing the model.
 seo_title: Modeling Count Events with Poisson Distribution in R
 seo_type: article
 tags:
-- Poisson distribution
-- Count data
-- Statistical modeling
-- Time series analysis
-- Event data
-- Data preparation
-- R code
 - Probability
-- P-value analysis
-- Statistical testing
-- R
+- Data Analysis
+- Statistical Modeling
+- Time Series
+- Data Quality
+- Hypothesis Testing
 title: Modeling Count Events with Poisson Distribution in R
 ---
 

--- a/_posts/2024-06-05-data_science_health_tech.md
+++ b/_posts/2024-06-05-data_science_health_tech.md
@@ -2,10 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Mathematics
-- Statistics
-- Data Analysis
-- Healthcare Technology
 classes: wide
 date: '2024-06-05'
 header:
@@ -26,6 +22,8 @@ keywords:
 - Machine learning for health
 - Healthcare operations improvement
 - Patient outcomes and ai
+redirect_from:
+- '/data science/mathematics/statistics/data analysis/healthcare technology/data_science_health_tech/'
 seo_description: How data science is transforming healthcare through predictive analytics, machine learning, personalized medicine, and real-time monitoring.
 seo_title: The Advantages of Data Science in Healthcare Technology
 seo_type: article
@@ -33,28 +31,11 @@ summary: This article explores how data science is transforming healthcare techn
   focusing on predictive analytics, early diagnosis, personalized medicine, and improving
   patient outcomes through machine learning and real-time monitoring.
 tags:
-- Data science
-- Health tech
-- Predictive analytics
-- Early diagnosis
-- Personalized medicine
-- Operational efficiency
-- Patient outcomes
-- Machine learning
-- Electronic health records (ehrs)
-- Genetic data
-- Wearable devices
-- Real-time monitoring
-- Chronic disease management
-- Medical data analytics
-- Predictive healthcare
-- Personalized healthcare
-- Healthcare operations
-- Patient care improvement
-- Health informatics
-- Artificial intelligence in healthcare
-- Healthcare management
-- Digital health solutions
+- Data Science
+- Machine Learning
+- Healthcare
+- Predictive Maintenance
+- Model Monitoring
 title: The Advantages of Using Data Science in Health Tech
 ---
 

--- a/_posts/2024-06-05-sensor_activations_models.md
+++ b/_posts/2024-06-05-sensor_activations_models.md
@@ -29,22 +29,12 @@ summary: This tutorial explores how to model sensor activations using the Poisso
   distribution in Python, covering data preparation, model evaluation, residual analysis,
   and cross-validation techniques.
 tags:
-- Poisson distribution
-- Count data
-- Statistical modeling
-- Sensor activations
-- Data preparation
-- Model evaluation
-- Residual analysis
-- Goodness-of-fit
-- Cross-validation
-- Time series analysis
-- Data science
-- Statistics
-- Data analysis
-- Python programming
-- Educational tutorial
-- Python
+- Probability
+- Data Analysis
+- Statistical Modeling
+- Industrial IoT
+- Data Quality
+- Model Evaluation
 title: Modeling Sensor Activations with Poisson Distribution in Python
 ---
 

--- a/_posts/2024-06-06-Essential_Statistical.md
+++ b/_posts/2024-06-06-Essential_Statistical.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Mathematics
-- Statistics
-- Data Analysis
 classes: wide
 date: '2024-06-06'
 header:
@@ -14,17 +11,17 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_8.jpg
   twitter_image: /assets/images/data_science_7.jpg
+redirect_from:
+- '/data science/mathematics/statistics/data analysis/Essential_Statistical/'
 seo_description: The statistical concepts every data analyst needs, from descriptive measures like mean and median to interpreting data.
 seo_title: Essential Statistical Concepts for Data Analysts
 seo_type: article
 tags:
-- Descriptive statistics
-- Inferential statistics
-- Probability distributions
-- Sampling techniques
-- Bayesian statistics
-- Time series analysis
-- Multivariate analysis
+- Descriptive Statistics
+- Probability
+- Bayesian Statistics
+- Time Series
+- Multivariate Analysis
 title: Essential Statistical Concepts for Data Analysts
 ---
 

--- a/_posts/2024-06-06-wine_sensory_evaluation.md
+++ b/_posts/2024-06-06-wine_sensory_evaluation.md
@@ -1,13 +1,7 @@
 ---
 author_profile: false
 categories:
-- Wine Science
-- Sensory Evaluation
-- Data Analysis
-- Oenology
-- Food Science
-- Consumer Behavior
-- Marketing
+- Data Science
 classes: wide
 date: '2024-06-06'
 header:
@@ -17,20 +11,17 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_2.jpg
   twitter_image: /assets/images/data_science_8.jpg
+redirect_from:
+- '/wine science/sensory evaluation/data analysis/oenology/food science/consumer behavior/marketing/wine_sensory_evaluation/'
 seo_description: How wine sensory evaluation works, from sensory lexicons and emotional response to the statistical techniques used to analyze results.
 seo_title: Wine Sensory Evaluation and Statistical Analysis
 seo_type: article
 tags:
-- Sensory lexicon
-- Wine tasting
-- Emotions
-- Consumer preferences
-- Descriptive statistics
-- Multivariate analysis
-- Pca
-- Anova
-- Regression analysis
-- Wine quality
+- Descriptive Statistics
+- Multivariate Analysis
+- Dimensionality Reduction
+- Hypothesis Testing
+- Regression
 title: 'Wine Sensory Evaluation: From Sensory Lexicons and Emotions to Data Statistical
   Analysis Techniques'
 ---

--- a/_posts/2024-06-07-zscore.md
+++ b/_posts/2024-06-07-zscore.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Statistics
 classes: wide
 date: '2024-06-07'
 header:
@@ -24,6 +23,8 @@ keywords:
 - R programming
 - Data comparison techniques
 - R
+redirect_from:
+- '/data science/statistics/zscore/'
 seo_description: Z-Scores for standardizing data, detecting outliers, and comparing points across datasets, with practical examples in R.
 seo_title: 'Z-Scores: A Quick Guide to Standard Scores'
 seo_type: article
@@ -31,16 +32,10 @@ summary: This tutorial provides an introduction to Z-Scores, explaining their ro
   in standardizing data, detecting outliers, and comparing data points across different
   datasets, with examples in R programming.
 tags:
-- Z-score
-- Standard score
-- Data standardization
-- Outlier detection
-- Mean
-- Standard deviation
-- R language
-- Data comparison
-- Statistical analysis
-- Normal distribution
+- Descriptive Statistics
+- Anomaly Detection
+- Statistical Modeling
+- Probability
 - R
 title: 'Data Analysis Skills with Z-Scores: A Quick Guide'
 ---

--- a/_posts/2024-06-11-survival_analysis.md
+++ b/_posts/2024-06-11-survival_analysis.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Medical Research
 classes: wide
 date: '2024-06-11'
 header:
@@ -14,21 +11,17 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_2.jpg
   twitter_image: /assets/images/data_science_7.jpg
+redirect_from:
+- '/mathematics/statistics/data science/medical research/survival_analysis/'
 seo_description: Parametric and non-parametric approaches to estimating survival functions, their assumptions, and where each applies.
 seo_title: 'Estimating Survival Functions: Two Approaches'
 seo_type: article
 subtitle: A Comprehensive Guide to Survival Function Estimation Methods
 tags:
-- Survival analysis
-- Kaplan-meier estimator
-- Exponential survival function
-- Parametric methods
-- Non-parametric methods
-- Censoring
-- Customer churn
-- Lifetime value
-- Curve fitting
-- Medical statistics
+- Survival Analysis
+- Statistical Modeling
+- Nonparametric Methods
+- Customer Analytics
 - Python
 title: 'Estimating Survival Functions: Parametric and Non-Parametric Approaches'
 ---

--- a/_posts/2024-06-12-DBSCAN.md
+++ b/_posts/2024-06-12-DBSCAN.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Machine Learning
 classes: wide
 date: '2024-06-12'
 header:
@@ -14,21 +11,17 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_1.jpg
   twitter_image: /assets/images/data_science_8.jpg
+redirect_from:
+- '/mathematics/statistics/data science/machine learning/DBSCAN/'
 seo_description: DBSCAN++, a faster and more scalable alternative to DBSCAN clustering, with its mathematical formulation and applications.
 seo_title: 'DBSCAN++: A Faster Alternative to DBSCAN'
 seo_type: article
 subtitle: Enhancing Density-Based Clustering with Improved Efficiency and Scalability
 tags:
-- Dbscan
-- Dbscan++
-- Clustering algorithms
-- Data science
-- Kmeans limitations
-- Scalable clustering
-- Noise handling
-- Anomaly detection
-- Geospatial data analysis
-- Large-scale data analysis
+- Clustering
+- Data Science
+- Anomaly Detection
+- Data Analysis
 title: 'DBSCAN++: The Faster and Scalable Alternative to DBSCAN Clustering'
 ---
 

--- a/_posts/2024-06-13-Stepwise_regression.md
+++ b/_posts/2024-06-13-Stepwise_regression.md
@@ -15,20 +15,12 @@ seo_description: How stepwise regression works, the criteria used for variable s
 seo_title: 'Stepwise Regression: Methods and Concerns'
 seo_type: article
 tags:
-- Stepwise regression
-- Model selection
-- Regression analysis
-- Overfitting
-- Statistical methods
-- Predictive modeling
-- Forward selection
-- Backward elimination
-- Efroymson algorithm
+- Regression
+- Statistical Modeling
+- Regularization
+- Machine Learning
 - Python
 - R
-- Julia
-- Statistics
-- Data science
 title: 'Stepwise Regression: Methodology, Applications, and Concerns'
 ---
 

--- a/_posts/2024-06-14-matthew_correlation.md
+++ b/_posts/2024-06-14-matthew_correlation.md
@@ -33,27 +33,12 @@ seo_type: article
 subtitle: Understanding and Applying MCC in Binary Classification
 summary: This article provides a comprehensive explanation of Matthew’s Correlation Coefficient (MCC), its importance in binary classification, and how it compares to other performance metrics like accuracy, precision, and recall.
 tags:
-- Mcc
-- Evaluation metrics
-- Binary classification
-- Machine learning
-- Statistical methods
-- Confusion matrix
-- Predictive modeling
-- Performance metrics
-- Data analysis
+- Model Evaluation
+- Classification
+- Machine Learning
+- Statistical Modeling
+- Data Analysis
 - Python
-- Fortran
-- Sh
-- C
-- Python
-- Fortran
-- Sh
-- C
-- python
-- fortran
-- sh
-- c
 title: 'Matthew’s Correlation Coefficient (MCC): A Detailed Explanation'
 ---
 

--- a/_posts/2024-06-15-EMI_RSSI_SIGNAL.md
+++ b/_posts/2024-06-15-EMI_RSSI_SIGNAL.md
@@ -1,10 +1,7 @@
 ---
 author_profile: false
 categories:
-- Wireless Communication
-- Signal Processing
-- Data Science
-- Network Engineering
+- Predictive Maintenance
 classes: wide
 date: '2024-06-15'
 header:
@@ -14,20 +11,14 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_2.jpg
   twitter_image: /assets/images/data_science_8.jpg
+redirect_from:
+- '/wireless communication/signal processing/data science/network engineering/EMI_RSSI_SIGNAL/'
 seo_description: How electromagnetic interference degrades RSSI in wireless systems, and what it means for signal quality and reliability.
 seo_title: How Electromagnetic Interference Affects RSSI
 seo_type: article
 tags:
-- Rssi
-- Electromagnetic interference
-- Signal strength
-- Noise
-- Wireless networks
-- Signal degradation
-- Emi mitigation
-- Frequency selection
-- Data quality
-- Network performance
+- Industrial IoT
+- Data Quality
 title: 'Impact of Electromagnetic Interference on RSSI Signal: Detailed Insights and
   Implications'
 ---

--- a/_posts/2024-06-19-Frequentis_Bayesian.md
+++ b/_posts/2024-06-19-Frequentis_Bayesian.md
@@ -2,10 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Philosophy
-- Probability
 classes: wide
 date: '2024-06-19'
 header:
@@ -15,24 +11,19 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_7.jpg
   twitter_image: /assets/images/data_science_1.jpg
+redirect_from:
+- '/mathematics/statistics/data science/philosophy/probability/Frequentis_Bayesian/'
 seo_description: The Sunrise Problem compared through Bayesian and frequentist lenses, and what it reveals about inference from limited data.
 seo_title: 'The Sunrise Problem: Bayesian vs Frequentist'
 seo_type: article
 subtitle: Understanding the Probability of the Sun Rising Tomorrow
 tags:
-- Bayesian inference
-- Frequentist probability
-- Rule of succession
-- Sunrise problem
-- Richard price
-- Thomas bayes
-- Probability theory
-- Risk assessment
-- Reliability engineering
-- Medical diagnostics
-- Hypothesis testing
-- Survival analysis
-- Philosophy of science
+- Bayesian Statistics
+- Probability
+- Risk Management
+- Healthcare
+- Hypothesis Testing
+- Survival Analysis
 title: 'The Sunrise Problem: A Bayesian vs Frequentist Perspective'
 ---
 

--- a/_posts/2024-06-19-outliers_advanced_topics.md
+++ b/_posts/2024-06-19-outliers_advanced_topics.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Data Analysis
 classes: wide
 date: '2024-06-19'
 header:
@@ -14,20 +11,18 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_3.jpg
   twitter_image: /assets/images/data_science_5.jpg
+redirect_from:
+- '/mathematics/statistics/data science/data analysis/outliers_advanced_topics/'
 seo_description: Types and causes of outliers in data analysis, and the visual and statistical methods used to detect them.
 seo_title: 'Outliers in Data Analysis: Advanced Techniques'
 seo_type: article
 tags:
-- Outliers
-- Robust statistics
-- Data analysis
-- Measurement error
-- Heavy-tailed distributions
-- Mixture models
-- Extreme observations
-- Novelty detection
-- Box plots
-- Statistical methods
+- Anomaly Detection
+- Robust Statistics
+- Data Analysis
+- Data Quality
+- Probability
+- Statistical Modeling
 title: 'Exploring Outliers in Data Analysis: Advanced Concepts and Techniques'
 ---
 

--- a/_posts/2024-06-26-missing_data.md
+++ b/_posts/2024-06-26-missing_data.md
@@ -1,11 +1,7 @@
 ---
 author_profile: false
 categories:
-- Epidemiology
 - Data Science
-- Medical Research
-- Statistics
-- Clinical Studies
 classes: wide
 date: '2024-06-26'
 header:
@@ -15,21 +11,16 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_8.jpg
   twitter_image: /assets/images/data_science_6.jpg
+redirect_from:
+- '/epidemiology/data science/medical research/statistics/clinical studies/missing_data/'
 seo_description: How to handle missing data in clinical research, the biases that arise when it is ignored, and the methods that address it.
 seo_title: Handling Missing Data in Clinical Research
 seo_type: article
 subtitle: Strategies and Guidelines for Ensuring Valid Results
 tags:
-- Missing data
-- Multiple imputation
-- Complete case analysis
-- Missing data mechanisms
-- Mcar
-- Mar
-- Mnar
-- Data imputation
-- Research methodology
-- Statistical analysis
+- Missing Data
+- Research Methodology
+- Statistical Modeling
 title: Handling Missing Data in Clinical Research
 ---
 

--- a/_posts/2024-06-29-GLM.md
+++ b/_posts/2024-06-29-GLM.md
@@ -1,11 +1,7 @@
 ---
 author_profile: false
 categories:
-- Epidemiology
 - Data Science
-- Medical Research
-- Statistics
-- Clinical Studies
 classes: wide
 date: '2024-06-29'
 header:
@@ -15,19 +11,17 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_8.jpg
   twitter_image: /assets/images/data_science_1.jpg
+redirect_from:
+- '/epidemiology/data science/medical research/statistics/clinical studies/GLM/'
 seo_description: How Generalized Linear Models handle diverse data types, the main GLM families, and the extensions that build on them.
 seo_title: Statistical Analysis with Generalized Linear Models
 seo_type: article
 subtitle: Strategies and Guidelines for Ensuring Valid Results
 tags:
-- Glms
-- Wald's test
-- Generalized estimating equations
-- Multiple comparisons
-- Model fit
-- Logistic regression
-- Statistical analysis
-- Bash
+- Statistical Modeling
+- Hypothesis Testing
+- Regression
+- Programming
 - Python
 title: Statistical Analysis with Generalized Linear Models
 ---

--- a/_posts/2024-06-29-latente.md
+++ b/_posts/2024-06-29-latente.md
@@ -2,10 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Machine Learning
-- Physics
-- Artificial Intelligence
-- Research Methodology
 classes: wide
 date: '2024-06-29'
 header:
@@ -15,21 +11,16 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_9.jpg
   twitter_image: /assets/images/data_science_7.jpg
+redirect_from:
+- '/statistics/machine learning/physics/artificial intelligence/research methodology/latente/'
 seo_description: What latent variables are, where the term came from, and the role they play in statistics and machine learning.
 seo_title: 'Latent Variables: Definition and History'
 seo_type: article
 subtitle: Understanding the Hidden Dimensions in Data
 tags:
-- Latent variables
-- Hidden variables
-- Hypothetical constructs
-- Dimensionality reduction
-- Factor analysis
-- Mixed-effects models
-- Hidden markov models
-- Statistical methods
-- Historical perspective
-- Future trends
+- Statistical Modeling
+- Dimensionality Reduction
+- Stochastic Processes
 title: 'Latent Variables: Explained and Its History'
 ---
 

--- a/_posts/2024-06-30-RSSI_body_effects.md
+++ b/_posts/2024-06-30-RSSI_body_effects.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Wireless Communication
-- Signal Processing
-- Network Engineering
+- Predictive Maintenance
 classes: wide
 date: '2024-06-30'
 header:
@@ -24,6 +22,8 @@ keywords:
 - Signal quality in wireless communication
 - Antenna design adjustments
 - Python
+redirect_from:
+- '/wireless communication/signal processing/network engineering/RSSI_body_effects/'
 seo_description: How the human body affects RSSI in wireless communication through absorption, reflection, and shadowing, and how to mitigate it.
 seo_title: How the Human Body Affects RSSI Signals
 seo_type: article
@@ -31,16 +31,7 @@ summary: This article provides a comprehensive analysis of how the human body im
   RSSI, covering absorption, reflection, shadowing, and proximity effects, and offering
   practical approaches to mitigate signal interference.
 tags:
-- Rssi
-- Absorption
-- Reflection
-- Shadowing
-- Proximity effects
-- Capacitive coupling
-- Resonant effects
-- Antenna design
-- Dynamic adjustment
-- Signal quality
+- Industrial IoT
 - Python
 title: 'How the Human Body Affects RSSI: Detailed Analysis and Practical Approaches'
 ---

--- a/_posts/2024-06-30-RSSI_humanbody.md
+++ b/_posts/2024-06-30-RSSI_humanbody.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Signal Processing
+- Predictive Maintenance
 classes: wide
 date: '2024-06-30'
 excerpt: Explore the impact of human presence on RSSI and the challenges it introduces,
@@ -22,6 +22,8 @@ keywords:
 - Shadowing
 - Interference
 - Beamforming
+redirect_from:
+- '/signal processing/RSSI_humanbody/'
 seo_description: How the human body affects RSSI in wireless networks, and strategies for handling signal attenuation, interference, and multipath effects.
 seo_title: 'Effects of a Human Body on RSSI: Challenges and Mitigations'
 seo_type: article
@@ -29,16 +31,7 @@ summary: This article examines how human bodies affect Received Signal Strength 
   (RSSI), the resulting challenges like signal attenuation and interference, and key
   techniques for mitigating these effects.
 tags:
-- Rssi
-- Signal attenuation
-- Multipath effects
-- Shadowing
-- Interference
-- Antenna placement
-- Diversity techniques
-- Power control
-- High frequency bands
-- Beamforming
+- Industrial IoT
 title: 'Effects of a Human Body on RSSI: Challenges and Mitigations'
 ---
 

--- a/_posts/2024-06-30-latentclass.md
+++ b/_posts/2024-06-30-latentclass.md
@@ -15,23 +15,10 @@ seo_description: How Latent Class Analysis identifies unobservable subgroups in 
 seo_title: 'Latent Class Analysis: Finding Hidden Subgroups'
 seo_type: article
 tags:
-- Latent class analysis
-- Structural equation modeling
-- Multivariate categorical data
-- Latent classes
-- Conditional independence
-- Maximum likelihood estimation
-- Data simplification
-- Hidden patterns
-- Case study
-- Model specification
-- Estimation process
-- Class membership
-- Statistical modeling
-- Research applications
-- Data patterns
-- Decision making
-- Statistical independence
+- Statistical Modeling
+- Multivariate Analysis
+- Probability
+- Business Intelligence
 title: 'Latent Class Analysis: Unveiling Hidden Patterns in Data'
 ---
 

--- a/_posts/2024-07-01-Lasso.md
+++ b/_posts/2024-07-01-Lasso.md
@@ -2,10 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Machine Learning
-- Data Science
-- Regression Analysis
-- Predictive Modeling
 classes: wide
 date: '2024-07-01'
 header:
@@ -15,23 +11,18 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_7.jpg
   twitter_image: /assets/images/data_science_2.jpg
+redirect_from:
+- '/statistics/machine learning/data science/regression analysis/predictive modeling/Lasso/'
 seo_description: What LASSO regression is, why it works, and when to use it, compared with traditional regression methods.
 seo_title: 'LASSO Regression: What, Why, When, and When Not'
 seo_type: article
 tags:
-- Lasso
-- Variable selection
+- Regression
+- Feature Engineering
 - Regularization
-- High-dimensional data
-- Sparse models
-- Elastic net
-- Ridge regression
-- Ordinary least squares
-- Regression techniques
-- Statistical modeling
-- Feature selection
-- Multicollinearity
-- Model interpretability
+- Data Analysis
+- Statistical Modeling
+- Machine Learning
 title: 'LASSO Regression: What, Why, When, and When Not'
 ---
 

--- a/_posts/2024-07-02-monitoring_drift.md
+++ b/_posts/2024-07-02-monitoring_drift.md
@@ -35,20 +35,12 @@ summary: A deep dive into advanced machine learning monitoring techniques that e
   such as direct loss estimation, outlier detection, and best practices for addressing
   alarm fatigue in AI systems deployed in production.
 tags:
-- Data drift
-- Direct loss estimation
-- Ml monitoring
-- Model performance
-- Alarm fatigue
-- Predictive analytics
-- Data science best practices
-- Ai in production
-- Outliers detection
-- Data science
-- Model monitoring
-- Artificial intelligence
-- Technology
-- Python
+- Data Drift
+- Statistical Modeling
+- Model Monitoring
+- Machine Learning
+- Data Science
+- Artificial Intelligence
 title: 'Machine Learning Monitoring: Moving Beyond Univariate Data Drift Detection'
 ---
 

--- a/_posts/2024-07-03-ancova.md
+++ b/_posts/2024-07-03-ancova.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Science
-- Research Methods
 classes: wide
 date: '2024-07-03'
 header:
@@ -13,21 +11,18 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_2.jpg
   twitter_image: /assets/images/data_science_3.jpg
+redirect_from:
+- '/statistics/data science/research methods/ancova/'
 seo_description: Non-parametric ANCOVA and robust alternatives such as ART-ANOVA for when parametric assumptions do not hold.
 seo_title: Advanced Non-Parametric ANCOVA and Robust Alternatives
 seo_type: article
 tags:
-- Non-parametric methods
-- Ancova
-- Robust statistics
-- Data analysis
-- R programming
-- Statistical modeling
-- Longitudinal studies
-- Quantile regression
-- Generalized estimating equations
+- Nonparametric Methods
+- Robust Statistics
+- Data Analysis
 - R
-- Unknown
+- Statistical Modeling
+- Regression
 title: Advanced Non-Parametric ANCOVA and Robust Alternatives
 ---
 

--- a/_posts/2024-07-04-Logram_test.md
+++ b/_posts/2024-07-04-Logram_test.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Science
-- Survival Analysis
-- Hypothesis Testing
 classes: wide
 date: '2024-07-04'
 header:
@@ -14,19 +11,14 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_2.jpg
   twitter_image: /assets/images/data_science_7.jpg
+redirect_from:
+- '/statistics/data science/survival analysis/hypothesis testing/Logram_test/'
 seo_description: How the logrank test compares survival distributions between two groups, and why it matters in survival analysis.
 seo_title: The Logrank Test in Survival Analysis
 seo_type: article
 tags:
-- Logrank test
-- Survival probability
-- Chi-square test
-- Censoring
-- Cox proportional hazards model
-- Statistical significance
-- Observed events
-- Expected events
-- Hypothesis testing
+- Survival Analysis
+- Hypothesis Testing
 - Python
 - R
 title: Understanding the Logrank Test in Survival Analysis

--- a/_posts/2024-07-05-savitzky_golay.md
+++ b/_posts/2024-07-05-savitzky_golay.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Time Series Analysis
-- Machine Learning
-- Data Processing
 classes: wide
 date: '2024-07-05'
 header:
@@ -25,6 +22,8 @@ keywords:
 - Data visualization
 - Python
 - Unknown
+redirect_from:
+- '/data science/time series analysis/machine learning/data processing/savitzky_golay/'
 seo_description: 'Smoothing time series with Moving Averages and Savitzky-Golay filters: their differences, benefits, and Python implementations.'
 seo_title: Moving Averages vs. Savitzky-Golay Smoothing
 seo_type: article
@@ -32,15 +31,11 @@ summary: 'This article compares two popular techniques for smoothing time series
   Moving Averages and Savitzky-Golay filters, focusing on their applications, benefits,
   and implementation in Python.'
 tags:
-- Time series
-- Data smoothing
-- Moving averages
-- Savitzky-golay filter
+- Time Series
+- Signal Processing
 - Python
-- Data visualization
-- Signal processing
-- Data analysis
-- Unknown
+- Data Visualization
+- Data Analysis
 title: 'Smoothing Time Series Data: Moving Averages vs. Savitzky-Golay Filters'
 ---
 

--- a/_posts/2024-07-06-stepwise_selection.md
+++ b/_posts/2024-07-06-stepwise_selection.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Science
-- Regression Analysis
 classes: wide
 date: '2024-07-06'
 header:
@@ -13,14 +11,15 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_5.jpg
   twitter_image: /assets/images/data_science_5.jpg
+redirect_from:
+- '/statistics/data science/regression analysis/stepwise_selection/'
 seo_description: Why stepwise selection biases coefficients upward, the consequences for your estimates, and the broader implications.
 seo_title: Why Stepwise Selection Ruins Your Estimates
 seo_type: article
 tags:
-- Stepwise selection
-- Regression models
-- Statistical bias
-- Variable selection
+- Regression
+- Statistical Modeling
+- Feature Engineering
 title: Stepwise Selection Algorithms Almost Always Ruin Statistical Estimates
 ---
 

--- a/_posts/2024-07-07-logistic_model_explained.md
+++ b/_posts/2024-07-07-logistic_model_explained.md
@@ -31,19 +31,12 @@ seo_description: 'A guide to logistic regression: binary classification, logit m
 seo_title: 'The Logistic Model: Explained'
 seo_type: article
 tags:
-- Logistic regression
-- Logit model
-- Binary classification
+- Regression
+- Classification
 - Probability
-- Maximum-likelihood estimation
-- Odds ratio
-- Multinomial logistic regression
-- Ordinal logistic regression
-- Statistical modeling
-- Joseph berkson
-- Machine learning
-- Data science
-- Predictive modeling
+- Statistical Modeling
+- Machine Learning
+- Data Science
 title: 'The Logistic Model: Explained'
 ---
 

--- a/_posts/2024-07-08-pseudosupervised_outlier_detection.md
+++ b/_posts/2024-07-08-pseudosupervised_outlier_detection.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Statistics
-- Data Science
-- Machine Learning
 classes: wide
 date: '2024-07-08'
 header:
@@ -14,21 +11,18 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_9.jpg
   twitter_image: /assets/images/data_science_1.jpg
+redirect_from:
+- '/mathematics/statistics/data science/machine learning/pseudosupervised_outlier_detection/'
 seo_description: How pseudo-supervised outlier detection combines supervised and unsupervised approaches for finance, healthcare, and security.
 seo_title: Pseudo-Supervised Outlier Detection
 seo_type: article
 subtitle: Bridging the Gap Between Supervised and Unsupervised Anomaly Detection
 tags:
-- Pseudo-supervised learning
-- Outlier detection
-- Anomaly detection
-- Unsupervised learning
-- Supervised learning
-- Machine learning
-- Data science
-- Hybrid methods
-- Pseudo-labeling
-- Iterative refinement
+- Supervised Learning
+- Anomaly Detection
+- Unsupervised Learning
+- Machine Learning
+- Data Science
 - Python
 title: Pseudo-Supervised Outlier Detection
 ---

--- a/_posts/2024-07-09-understanding_use_error_bars_scientific_reporting.md
+++ b/_posts/2024-07-09-understanding_use_error_bars_scientific_reporting.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Research Methodology
+- Data Science
 classes: wide
 date: '2024-07-09'
 header:
@@ -21,6 +21,8 @@ keywords:
 - Statistical reporting
 - Scientific analysis
 - Error representation in research
+redirect_from:
+- '/research methodology/understanding_use_error_bars_scientific_reporting/'
 seo_description: How error bars represent variability, standard deviation, standard error, and confidence intervals in scientific reporting.
 seo_title: 'Understanding Error Bars: A Guide to Scientific Reporting'
 seo_type: article
@@ -28,17 +30,9 @@ summary: This article explores the significance of error bars in scientific repo
   focusing on their use in representing variability, standard deviation, standard
   error, and confidence intervals in research findings.
 tags:
-- Research paper writing
-- Academic writing tips
-- Thesis statement development
-- Research methodology
-- Error bars
-- Reporting
-- Findings
-- Science
-- Standard deviation
-- Standard error
-- Confidence interval
+- Research Methodology
+- Descriptive Statistics
+- Confidence Intervals
 title: Understanding the Use of Error Bars in Scientific Reporting
 ---
 

--- a/_posts/2024-07-10-normal_distribution.md
+++ b/_posts/2024-07-10-normal_distribution.md
@@ -16,8 +16,6 @@ seo_title: The Normal Distribution Explained
 seo_type: article
 tags:
 - Probability
-- Gaussian distribution
-- Central limit theorem
 title: 'Normal Distribution: Explained'
 ---
 

--- a/_posts/2024-07-10-prob_distributions_clinical.md
+++ b/_posts/2024-07-10-prob_distributions_clinical.md
@@ -27,9 +27,9 @@ seo_type: article
 summary: This article explores key probability distributions used in clinical trials,
   focusing on their applications in hypothesis testing and outcome analysis.
 tags:
-- Probability distributions
-- Clinical trials
-- Hypothesis testing
+- Probability
+- Experimental Design
+- Hypothesis Testing
 title: Common Probability Distributions in Clinical Trials
 ---
 

--- a/_posts/2024-07-11-pre_commit.md
+++ b/_posts/2024-07-11-pre_commit.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Python
+- Programming
 classes: wide
 date: '2024-07-11'
 header:
@@ -11,16 +11,15 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_6.jpg
   twitter_image: /assets/images/data_science_3.jpg
+redirect_from:
+- '/python/pre_commit/'
 seo_description: How pre-commit hooks enforce code quality in Python projects, and how to set them up in your Git workflow.
 seo_title: Pre-commit Hooks for Python Projects
 seo_type: article
 tags:
 - Python
-- Git
-- Pre-commit hooks
-- Devops
-- Bash
-- Yaml
+- MLOps
+- Programming
 title: Streamlining Your Workflow with Pre-commit Hooks in Python Projects
 ---
 

--- a/_posts/2024-07-12-NILM.md
+++ b/_posts/2024-07-12-NILM.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Energy Efficiency
-- Smart Technology
+- Predictive Maintenance
 classes: wide
 date: '2024-07-12'
 header:
@@ -12,13 +11,14 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_9.jpg
   twitter_image: /assets/images/data_science_2.jpg
+redirect_from:
+- '/energy efficiency/smart technology/NILM/'
 seo_description: 'Non-intrusive load monitoring (NILM) explained: how it measures appliance energy use without per-device hardware.'
 seo_title: 'Non-Intrusive Load Monitoring (NILM): A Guide'
 seo_type: article
 tags:
-- Nilm
-- Energy monitoring
-- Smart meters
+- Predictive Maintenance
+- Model Monitoring
 title: 'Non-Intrusive Load Monitoring: A Comprehensive Guide'
 ---
 

--- a/_posts/2024-07-13-CLT.md
+++ b/_posts/2024-07-13-CLT.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Probability Theory
 classes: wide
 date: '2024-07-13'
 header:
@@ -12,16 +11,13 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_1.jpg
   twitter_image: /assets/images/data_science_9.jpg
+redirect_from:
+- '/mathematics/probability theory/CLT/'
 seo_description: 'The main Central Limit Theorems compared, including Lindeberg-Levy, Lyapunov, Lindeberg-Feller, and Orey''s.'
 seo_title: 'Central Limit Theorems: An Overview'
 seo_type: article
 tags:
-- Central limit theorem
-- Lindeberg–lévy clt
-- Lyapunov clt
-- Lindeberg–feller clt
-- Orey's clt
-- Prokhorov's theorem
+- Probability
 - Python
 title: 'Central Limit Theorems: A Comprehensive Overview'
 ---

--- a/_posts/2024-07-13-NILM_Algorithms.md
+++ b/_posts/2024-07-13-NILM_Algorithms.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Energy Efficiency
-- Smart Technology
+- Predictive Maintenance
 classes: wide
 date: '2024-07-13'
 header:
@@ -12,13 +11,14 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_6.jpg
   twitter_image: /assets/images/data_science_3.jpg
+redirect_from:
+- '/energy efficiency/smart technology/NILM_Algorithms/'
 seo_description: How NILM algorithms disaggregate total building energy into individual appliance usage, from feature extraction to event detection.
 seo_title: NILM Algorithms for Energy Disaggregation
 seo_type: article
 tags:
-- Nilm
-- Energy monitoring
-- Smart meters
+- Predictive Maintenance
+- Model Monitoring
 title: 'Disaggregating Energy Consumption: The NILM Algorithms'
 ---
 

--- a/_posts/2024-07-14-confidenceintervales.md
+++ b/_posts/2024-07-14-confidenceintervales.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Science
 classes: wide
 date: '2024-07-14'
 header:
@@ -12,14 +11,14 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_1.jpg
   twitter_image: /assets/images/data_science_3.jpg
+redirect_from:
+- '/statistics/data science/confidenceintervales/'
 seo_description: The difference between confidence and prediction intervals, and what each tells you about uncertainty in an estimate.
 seo_title: Confidence vs. Prediction Intervals
 seo_type: article
 tags:
-- Uncertainty
-- Linear regression
-- Confidence interval
-- Prediction interval
+- Confidence Intervals
+- Regression
 title: 'Understanding Uncertainty in Statistical Estimates: Confidence and Prediction
   Intervals'
 ---

--- a/_posts/2024-07-15-outlier_detection_doping.md
+++ b/_posts/2024-07-15-outlier_detection_doping.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
 classes: wide
 date: '2024-07-15'
 header:
@@ -21,6 +20,8 @@ keywords:
 - Evaluating ml models
 - Robust data models
 - Python
+redirect_from:
+- '/data science/machine learning/outlier_detection_doping/'
 seo_description: How to test and evaluate outlier detection models with data doping, and how doping affects model performance.
 seo_title: Evaluating Outlier Detectors with Data Doping Techniques
 seo_type: article
@@ -28,9 +29,8 @@ summary: This article explores techniques for testing and evaluating outlier det
   models using data doping, highlighting key methodologies and their impact on model
   performance.
 tags:
-- Outlier detection
-- Data doping
-- Model evaluation
+- Anomaly Detection
+- Model Evaluation
 - Python
 title: Testing and Evaluating Outlier Detectors Using Doping
 ---

--- a/_posts/2024-07-16-Einstein.md
+++ b/_posts/2024-07-16-Einstein.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Data Analysis
+- Data Science
 classes: wide
 date: '2024-07-16'
 header:
@@ -19,6 +19,8 @@ keywords:
 - Software development best practices
 - Scientific research methods
 - Applying simplicity in technology
+redirect_from:
+- '/data analysis/Einstein/'
 seo_description: 'How Einstein''s principle of simplicity shapes scientific research, data analysis, communication, and software development.'
 seo_title: 'Einstein''s Principle of Simplicity in Practice'
 seo_type: article
@@ -26,12 +28,9 @@ summary: This article explores how Einstein's principle of simplicity can be app
   across various fields, including scientific research, data analysis, effective communication,
   and software development.
 tags:
-- Einstein
-- Simplicity
-- Scientific research
-- Data analysis
-- Effective communication
-- Software development
+- Research Methodology
+- Data Analysis
+- Programming
 title: Applying Einstein's Principle of Simplicity Across Disciplines
 ---
 

--- a/_posts/2024-07-17-outlier_algo.md
+++ b/_posts/2024-07-17-outlier_algo.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
-- Python
 classes: wide
 date: '2024-07-17'
 header:
@@ -13,13 +11,15 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_2.jpg
   twitter_image: /assets/images/data_science_3.jpg
+redirect_from:
+- '/data science/machine learning/python/outlier_algo/'
 seo_description: How the Counts Outlier Detector (COD) uses multi-dimensional histograms to find interpretable outliers in data.
 seo_title: Interpretable Outlier Detection with COD
 seo_type: article
 tags:
-- Outlier detection
-- Machine learning algorithms
-- Data analysis
+- Anomaly Detection
+- Machine Learning
+- Data Analysis
 title: Interpretable Outlier Detection with Counts Outlier Detector (COD)
 ---
 

--- a/_posts/2024-07-18-Outlier_PCA.md
+++ b/_posts/2024-07-18-Outlier_PCA.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
 classes: wide
 date: '2024-07-18'
 header:
@@ -12,13 +11,14 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_4.jpg
   twitter_image: /assets/images/data_science_1.jpg
+redirect_from:
+- '/data science/machine learning/Outlier_PCA/'
 seo_description: How Principal Component Analysis detects outliers, the difference between anomalies and novelties, and the methods available.
 seo_title: Detecting Outliers with PCA
 seo_type: article
 tags:
-- Pca
-- Outlier detection
-- Anomaly detection
+- Dimensionality Reduction
+- Anomaly Detection
 title: Detecting Outliers Using Principal Component Analysis (PCA)
 ---
 

--- a/_posts/2024-07-19-clt_revisited.md
+++ b/_posts/2024-07-19-clt_revisited.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Probability Theory
 - Statistics
-- Mathematical Analysis
 classes: wide
 date: '2024-07-19'
 excerpt: This article rigorously explores the Central Limit Theorem for m-dependent random variables under sub-linear expectations, presenting new inequalities, proof outlines, and implications in modeling dependent sequences.
@@ -20,15 +18,15 @@ keywords:
 - Sub-linear expectations
 - Rosenthal’s inequality
 - Truncated variables
+redirect_from:
+- '/probability theory/statistics/mathematical analysis/clt_revisited/'
 seo_description: 'Extending the Central Limit Theorem to m-dependent variables under sub-linear expectations, using Rosenthal''s inequality.'
 seo_title: Central Limit Theorem for m-dependent Random Variables
 seo_type: article
 summary: This article extends the classical Central Limit Theorem (CLT) to m-dependent random variables within the sub-linear expectation framework. It incorporates Rosenthal's inequality for m-dependent sequences, examines truncated conditions, and discusses the broader implications for real-world systems characterized by uncertainty and dependencies.
 tags:
-- Central limit theorem
-- M-dependence
-- Sub-linear expectations
-- Rosenthal’s inequality
+- Probability
+- Economics
 title: Central Limit Theorem for m-dependent Random Variables Under Sub-linear Expectations
 ---
 

--- a/_posts/2024-07-20-FPOF.md
+++ b/_posts/2024-07-20-FPOF.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Mathematics
-- Statistics
-- Data Science
 classes: wide
 date: '2024-07-20'
 header:
@@ -14,13 +11,15 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_5.jpg
   twitter_image: /assets/images/data_science_7.jpg
+redirect_from:
+- '/machine learning/mathematics/statistics/data science/FPOF/'
 seo_description: How the Frequent Patterns Outlier Factor identifies anomalies in unlabeled data, and why outlier detection matters.
 seo_title: Frequent Patterns Outlier Factor (FPOF)
 seo_type: article
 tags:
-- Outlier detection
-- Unsupervised learning
-- Data analysis
+- Anomaly Detection
+- Unsupervised Learning
+- Data Analysis
 - Python
 title: 'Frequent Patterns Outlier Factor '
 ---

--- a/_posts/2024-07-21-iknn.md
+++ b/_posts/2024-07-21-iknn.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Explainable AI
 date: '2024-07-21'
 header:
   image: /assets/images/data_science_7.jpg
@@ -11,13 +10,13 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_7.jpg
   twitter_image: /assets/images/data_science_2.jpg
+redirect_from:
+- '/machine learning/explainable ai/iknn/'
 seo_description: ikNN, an interpretable k-nearest neighbors model, and why interpretability sometimes matters more than raw accuracy.
 seo_title: 'ikNN: An Interpretable k-Nearest Neighbors Model'
 seo_type: article
 tags:
-- Interpretable models
-- Knn
-- Iknn
+- Clustering
 - Python
 title: 'Introducing ikNN: An Interpretable k Nearest Neighbors Model'
 ---

--- a/_posts/2024-07-30-Drift.md
+++ b/_posts/2024-07-30-Drift.md
@@ -15,9 +15,8 @@ seo_description: Why machine learning models lose accuracy over time, the causes
 seo_title: 'Drift in Machine Learning: Causes and Solutions'
 seo_type: article
 tags:
-- Model drift
-- Data science
-- Drift detection
+- Data Drift
+- Data Science
 title: 'Understanding Drift in Machine Learning: Causes, Types, and Solutions'
 ---
 

--- a/_posts/2024-07-31-Custom_libraries.md
+++ b/_posts/2024-07-31-Custom_libraries.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Python
+- Programming
 classes: wide
 date: '2024-07-31'
 excerpt: A guide on developing custom Python libraries to meet specific industry needs, focusing on software development and automation.
@@ -17,17 +17,16 @@ keywords:
 - Custom software development
 - Automation
 - Industry solutions
+redirect_from:
+- '/python/Custom_libraries/'
 seo_description: How to create custom Python libraries for industry-specific needs, covering software development and automation strategies.
 seo_title: Building Custom Python Libraries for Industry
 seo_type: article
 summary: This article explores the process of building custom Python libraries, offering insights into Python’s versatility for developing industry-specific software solutions and automation tools.
 tags:
-- Python libraries
-- Custom software
-- Industry solutions
-- Software development
-- Automation
 - Python
+- Programming
+- MLOps
 title: Building Custom Python Libraries for Your Industry Needs
 ---
 

--- a/_posts/2024-08-01-Data_leakeage.md
+++ b/_posts/2024-08-01-Data_leakeage.md
@@ -15,9 +15,7 @@ seo_description: What data leakage is, the forms it takes including feature, lab
 seo_title: 'Data Leakage in ML: Causes and Prevention'
 seo_type: article
 tags:
-- Data leakage
-- Data science
-- Model integrity
+- Data Science
 - Python
 title: 'Understanding Data Leakage in Machine Learning: Causes, Types, and Prevention'
 ---

--- a/_posts/2024-08-02-Drift_tecting.md
+++ b/_posts/2024-08-02-Drift_tecting.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Data Science
-- Artificial Intelligence
 classes: wide
 date: '2024-08-02'
 header:
@@ -13,13 +11,14 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_6.jpg
   twitter_image: /assets/images/data_science_8.jpg
+redirect_from:
+- '/machine learning/data science/artificial intelligence/Drift_tecting/'
 seo_description: How to detect concept drift when real-world data stops matching the stationary distribution your model assumed.
 seo_title: Detecting Concept Drift in Machine Learning
 seo_type: article
 tags:
-- Concept drift
-- Incremental learning
-- Drift detection method
+- Data Drift
+- Supervised Learning
 title: Detecting Concept Drift in Machine Learning
 ---
 

--- a/_posts/2024-08-03-feature_engineering.md
+++ b/_posts/2024-08-03-feature_engineering.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Data Science
 classes: wide
 date: '2024-08-03'
 excerpt: Discover the importance of feature engineering in enhancing machine learning
@@ -23,6 +22,8 @@ keywords:
 - Machine learning models
 - Predictive analytics
 - Python
+redirect_from:
+- '/machine learning/data science/feature_engineering/'
 seo_description: Explore powerful feature engineering techniques that boost the performance
   of machine learning models by improving data preprocessing and feature selection.
 seo_title: Feature Engineering for Better Machine Learning Models
@@ -31,11 +32,10 @@ summary: This article delves into various feature engineering techniques essenti
   for improving machine learning model performance. It covers data preprocessing,
   feature selection, transformation methods, and tips to enhance predictive accuracy.
 tags:
-- Feature engineering
-- Data preprocessing
-- Machine learning techniques
-- Feature selection
-- Model performance
+- Feature Engineering
+- Data Quality
+- Machine Learning
+- Model Monitoring
 - Python
 title: Feature Engineering Techniques for Improved Machine Learning
 ---

--- a/_posts/2024-08-15-structural_equations.md
+++ b/_posts/2024-08-15-structural_equations.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Research Methods
 classes: wide
 date: '2024-08-15'
 excerpt: Learn the fundamentals of Structural Equation Modeling (SEM) with latent
@@ -24,6 +23,8 @@ keywords:
 - Variance-covariance matrix
 - Measurement models
 - Exogenous and endogenous variables
+redirect_from:
+- '/statistics/research methods/structural_equations/'
 seo_description: 'A guide to Structural Equation Modeling (SEM) with latent variables: path analysis, measurement models, and exogenous vs endogenous variables.'
 seo_title: Guide to Structural Equation Modeling with Latent Variables
 seo_type: article
@@ -31,16 +32,9 @@ summary: This comprehensive guide explains the key concepts and techniques of St
   Equation Modeling (SEM) with latent variables. It includes path analysis, factor
   loadings, variance-covariance matrices, and handling endogenous and exogenous variables.
 tags:
-- Structural equation modeling (sem)
-- Latent variables
-- Measurement model
-- Factor loadings
-- Variance-covariance matrix
-- Path analysis
-- Causal relationships
-- Error variance
-- Endogenous variables
-- Exogenous variables
+- Statistical Modeling
+- Correlation
+- Descriptive Statistics
 title: A Comprehensive Guide to Structural Equation Modeling with Latent Variables
 ---
 

--- a/_posts/2024-08-16-utility_functions_python.md
+++ b/_posts/2024-08-16-utility_functions_python.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Programming
-- Python
-- Software Development
 classes: wide
 date: '2024-08-16'
 excerpt: Learn how to design and implement utility classes in Python. This guide covers
@@ -23,6 +21,8 @@ keywords:
 - Code reusability
 - Software development
 - Design patterns
+redirect_from:
+- '/programming/python/software development/utility_functions_python/'
 seo_description: Designing and implementing Python utility classes, with examples and best practices for building reusable object-oriented components.
 seo_title: 'Python Utility Classes: Design and Implementation Guide'
 seo_type: article
@@ -31,10 +31,7 @@ summary: This article provides a deep dive into Python utility classes, discussi
   principles and shows how to build reusable and efficient utility classes in Python.
 tags:
 - Python
-- Utility classes
-- Object-oriented programming
-- Code reusability
-- Software design patterns
+- Programming
 title: 'Python Utility Classes: Best Practices and Examples'
 ---
 

--- a/_posts/2024-08-19-pre_comit_tutorial.md
+++ b/_posts/2024-08-19-pre_comit_tutorial.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Python
-- Software Development
-- Version Control
+- Programming
 classes: wide
 date: '2024-08-19'
 excerpt: Learn how to use pre-commit tools in Python to enforce code quality and consistency
@@ -25,6 +23,8 @@ keywords:
 - Python development workflow
 - Bash
 - Yaml
+redirect_from:
+- '/python/software development/version control/pre_comit_tutorial/'
 seo_description: Pre-commit tools in Python for code quality and Git hooks, and how to integrate automated checks into your development process.
 seo_title: 'Pre-Commit Tools in Python: Best Practices and Guide'
 seo_type: article
@@ -34,13 +34,8 @@ summary: This guide provides an in-depth overview of pre-commit tools in Python,
   the development process.
 tags:
 - Python
-- Pre-commit
-- Code quality
-- Git hooks
-- Version control
-- Automation
-- Bash
-- Yaml
+- MLOps
+- Programming
 title: A Comprehensive Guide to Pre-Commit Tools in Python
 ---
 

--- a/_posts/2024-08-24-circular_economy.md
+++ b/_posts/2024-08-24-circular_economy.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Sustainability
 - Data Science
-- Circular Economy
 classes: wide
 date: '2024-08-24'
 excerpt: Explore how Python and network analysis can be used to implement and optimize
@@ -24,6 +22,8 @@ keywords:
 - Sustainability models
 - Resource efficiency
 - Python
+redirect_from:
+- '/sustainability/data science/circular economy/circular_economy/'
 seo_description: How to implement circular economy models with Python and network analysis, using data science and systems thinking for sustainability.
 seo_title: Circular Economy Models with Python and Network Analysis
 seo_type: article
@@ -32,11 +32,7 @@ summary: This article explores the implementation of circular economy models usi
   can be applied to improve resource efficiency, sustainability, and waste reduction.
 tags:
 - Python
-- Network analysis
-- Circular economy
-- Sustainability
-- Systems thinking
-- Resource efficiency
+- Graph Theory
 title: Implementing Circular Economy Models with Python and Network Analysis
 ---
 

--- a/_posts/2024-08-24-kruskal_wallis.md
+++ b/_posts/2024-08-24-kruskal_wallis.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Analysis
 classes: wide
 date: '2024-08-24'
 excerpt: Discover the Kruskal-Wallis Test, a powerful non-parametric statistical method
@@ -23,6 +22,8 @@ keywords:
 - Statistical data analysis
 - R
 - Python
+redirect_from:
+- '/statistics/data analysis/kruskal_wallis/'
 seo_description: 'The Kruskal-Wallis test, a non-parametric alternative to ANOVA for independent samples: its assumptions and how to interpret results.'
 seo_title: 'Kruskal-Wallis Test: A Non-Parametric Guide'
 seo_type: article
@@ -31,11 +32,8 @@ summary: This comprehensive guide explains the Kruskal-Wallis Test, a non-parame
   normal distribution. It discusses when to use the test, its assumptions, and how
   to interpret the results in data analysis.
 tags:
-- Kruskal-wallis test
-- Non-parametric methods
-- Anova
-- Statistical tests
-- Hypothesis testing
+- Hypothesis Testing
+- Nonparametric Methods
 - R
 - Python
 title: 'The Kruskal-Wallis Test: A Comprehensive Guide to Non-Parametric Analysis'

--- a/_posts/2024-08-25-Vehicle_Routing_Problem.md
+++ b/_posts/2024-08-25-Vehicle_Routing_Problem.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Operations Research
-- Data Science
-- Logistics
+- Economics
 classes: wide
 date: '2024-08-25'
 excerpt: Learn how to solve the Vehicle Routing Problem (VRP) using Python and optimization
@@ -25,6 +23,8 @@ keywords:
 - Supply chain management
 - Bash
 - Python
+redirect_from:
+- '/operations research/data science/logistics/Vehicle_Routing_Problem/'
 seo_description: How to solve the Vehicle Routing Problem (VRP) in Python, covering optimization techniques for transportation and logistics.
 seo_title: Solving the Vehicle Routing Problem in Python
 seo_type: article
@@ -33,13 +33,12 @@ summary: This comprehensive guide explains how to solve the Vehicle Routing Prob
   in transportation, logistics, and supply chain management to improve operational
   efficiency.
 tags:
-- Vehicle routing problem
+- Supply Chain
 - Python
 - Optimization
 - Transportation
-- Algorithms
-- Logistics
-- Bash
+- Machine Learning
+- Programming
 title: Implementing Vehicle Routing Problem Solutions with Python
 ---
 

--- a/_posts/2024-08-26-energie.md
+++ b/_posts/2024-08-26-energie.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Energy Management
+- Data Science
 classes: wide
 date: '2024-08-26'
 excerpt: Explore energy optimization strategies for production facilities to reduce
@@ -22,6 +22,8 @@ keywords:
 - Energy efficiency
 - Operational flexibility
 - Python
+redirect_from:
+- '/energy management/energie/'
 seo_description: How to implement energy optimization models in production facilities to cut costs, improve efficiency, and add operational flexibility.
 seo_title: Energy Optimization in Production Facilities
 seo_type: article
@@ -30,16 +32,9 @@ summary: This article provides an in-depth look at energy optimization models de
   machine flexibility, and optimization algorithms to reduce energy costs and enhance
   production efficiency.
 tags:
-- Energy optimization
-- Production facility
-- Cost savings
-- Cogeneration plants
-- Optimization algorithms
-- Energy efficiency
-- Operational flexibility
-- Machine flexibility
-- Energy costs
-- Production efficiency
+- Optimization
+- Machine Learning
+- Climate and Environment
 - Python
 title: 'Energy Optimization for a Production Facility: A Model for Cost Savings'
 ---

--- a/_posts/2024-08-27-coeeficient_variation.md
+++ b/_posts/2024-08-27-coeeficient_variation.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Analysis
 classes: wide
 date: '2024-08-27'
 excerpt: Learn how to calculate and interpret the Coefficient of Variation (CV), a
@@ -23,6 +22,8 @@ keywords:
 - Relative standard deviation
 - Interpreting data variability
 - Rust
+redirect_from:
+- '/statistics/data analysis/coeeficient_variation/'
 seo_description: The Coefficient of Variation (CV) as a tool for assessing variability, with its advantages and limitations in data analysis.
 seo_title: 'Coefficient of Variation: Uses and Limitations'
 seo_type: article
@@ -31,12 +32,8 @@ summary: This article explains the Coefficient of Variation (CV), a statistical 
   like economics, biology, and finance, as well as its limitations when interpreting
   data with different units or scales.
 tags:
-- Coefficient of variation
-- Statistical measures
-- Variability
-- Data interpretation
-- Relative standard deviation
-- Rust
+- Descriptive Statistics
+- Programming
 title: 'Understanding the Coefficient of Variation: Applications and Limitations'
 ---
 

--- a/_posts/2024-08-28-mathematics.md
+++ b/_posts/2024-08-28-mathematics.md
@@ -2,9 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Education
-- Technology
-- Society
 classes: wide
 date: '2024-08-28'
 excerpt: Explore how mathematics shapes modern society across fields like technology,
@@ -24,6 +21,8 @@ keywords:
 - Technology and math
 - Societal impact of mathematics
 - Mathematical thinking
+redirect_from:
+- '/mathematics/education/technology/society/mathematics/'
 seo_description: The role mathematics plays in modern society, from technological advancement to education, and how it drives innovation.
 seo_title: Mathematics in Modern Society
 seo_type: article
@@ -32,11 +31,8 @@ summary: This article highlights the undervalued role of mathematics in modern s
   discusses how mathematical thinking underpins innovation, problem-solving, and advancements
   across various industries.
 tags:
-- Mathematics
-- Technology
-- Education
-- Society
-- Innovation
+- Mathematical Modeling
+- Research Methodology
 title: The Undervalued Power of Mathematics in Modern Society
 ---
 

--- a/_posts/2024-08-31-adaptive_performance_estimation_machine_learning.md
+++ b/_posts/2024-08-31-adaptive_performance_estimation_machine_learning.md
@@ -30,12 +30,9 @@ summary: This article dives into adaptive performance estimation techniques in m
   and Predictive Adaptive Performance Estimation (PAPE). It covers their roles in
   detecting data drift, covariate shift, and maintaining optimal model performance.
 tags:
-- Machine learning
-- Performance monitoring
-- Data drift
-- Covariate shift
-- Cbpe
-- Pape
+- Machine Learning
+- Model Monitoring
+- Data Drift
 title: 'Adaptive Performance Estimation in Machine Learning: From CBPE to PAPE'
 ---
 

--- a/_posts/2024-08-31-pedestrian_movement.md
+++ b/_posts/2024-08-31-pedestrian_movement.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Simulation Models
+- Data Science
 classes: wide
 date: '2024-08-31'
 excerpt: Explore the simulation of pedestrian evacuation in environments impacted
@@ -24,6 +24,8 @@ keywords:
 - Bash
 - Python
 - Fortran
+redirect_from:
+- '/simulation models/pedestrian_movement/'
 seo_description: Simulating pedestrian evacuation in smoke-affected spaces with the Social Force Model and Advection-Diffusion Equation.
 seo_title: Pedestrian Evacuation in Smoke-Filled Spaces
 seo_type: article
@@ -32,15 +34,10 @@ summary: This article examines simulation models for pedestrian evacuation in sm
   the Advection-Diffusion Equation, and numerical methods for optimizing evacuation
   strategies during emergencies.
 tags:
-- Pedestrian evacuation
-- Smoke propagation
-- Social force model
-- Advection-diffusion equation
-- Numerical methods
-- Emergency preparedness
-- Bash
+- Transportation
+- Numerical Methods
+- Programming
 - Python
-- Fortran
 title: Simulating Pedestrian Evacuation in Smoke-Affected Environments
 ---
 

--- a/_posts/2024-09-01-graph_theory.md
+++ b/_posts/2024-09-01-graph_theory.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Production Systems
-- Supply Chain Management
+- Economics
 classes: wide
 date: '2024-09-01'
 excerpt: Explore how graph theory is applied to optimize production systems and supply
@@ -22,6 +21,8 @@ keywords:
 - Supply chain management
 - Optimization strategies
 - Production systems efficiency
+redirect_from:
+- '/production systems/supply chain management/graph_theory/'
 seo_description: How graph theory optimizes production systems and supply chains through network optimization and resource allocation.
 seo_title: Graph Theory for Supply Chain Optimization
 seo_type: article
@@ -30,11 +31,9 @@ summary: This article examines the practical applications of graph theory in opt
   allocation techniques that enhance operational efficiency and decision-making in
   supply chain management.
 tags:
-- Graph theory
-- Network optimization
-- Resource allocation
-- Supply chain efficiency
-- Production systems
+- Graph Theory
+- Optimization
+- Supply Chain
 title: Graph Theory Applications in Production Systems and Supply Chains
 ---
 

--- a/_posts/2024-09-01-math_music.md
+++ b/_posts/2024-09-01-math_music.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Music
-- Technology
 classes: wide
 date: '2024-09-01'
 excerpt: Discover how mathematics influences electronic music creation through sound
@@ -23,6 +21,8 @@ keywords:
 - Digital signal processing
 - Generative music
 - Rhythm and numbers
+redirect_from:
+- '/mathematics/music/technology/math_music/'
 seo_description: How mathematics drives electronic music, from sound synthesis to algorithmic composition, rhythm, and signal processing.
 seo_title: The Mathematics of Electronic Music
 seo_type: article
@@ -31,12 +31,7 @@ summary: This article explores the intersection of mathematics and electronic mu
   rhythm, and generative music creation. It delves into the technical aspects of digital
   signal processing and algorithmic composition in music technology.
 tags:
-- Sound synthesis
-- Algorithmic composition
-- Digital signal processing
-- Rhythm
-- Generative music
-- Mathematics in music
+- Signal Processing
 title: 'Mathematics and Electronic Music: The Symphony of Numbers'
 ---
 

--- a/_posts/2024-09-03-climate_change.md
+++ b/_posts/2024-09-03-climate_change.md
@@ -34,12 +34,10 @@ summary: As the climate crisis intensifies, data science has emerged as a key pl
   is shaping the future of environmental science and policy-making, helping us tackle
   one of the greatest challenges of our time.
 tags:
-- Climate modeling
-- Data analysis
-- Renewable energy
-- Risk assessment
-- Policy-making
-- Machine learning
+- Climate and Environment
+- Data Analysis
+- Risk Management
+- Machine Learning
 title: 'Data Science and the Climate Crisis: Innovative Approaches to Understanding
   and Mitigating Global Warming'
 ---

--- a/_posts/2024-09-03-fundamentals_matter.md
+++ b/_posts/2024-09-03-fundamentals_matter.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Technology
 classes: wide
 date: '2024-09-03'
 excerpt: Learn why a deep understanding of machine learning fundamentals is more valuable than expertise in specific tools and frameworks.
@@ -22,14 +21,14 @@ keywords:
 - Machine learning success
 - Adapting to new tools
 - Technology in machine learning
+redirect_from:
+- '/machine learning/technology/fundamentals_matter/'
 seo_description: Why mastering machine learning fundamentals matters more than mastering specific tools, and the principles behind successful projects.
 seo_title: 'Machine Learning Fundamentals vs Tools: What Matters Most'
 seo_type: article
 summary: Machine learning has become one of the most influential fields in technology today, with new tools and frameworks constantly emerging. However, despite the rapid development of sophisticated software, it's the foundational principles of machine learning that ultimately determine success. In this article, we explore why a strong grasp of the fundamentals—such as algorithms, data preprocessing, and model evaluation—matters more than expertise in any specific tool. By understanding these core concepts, data scientists and engineers can adapt to new tools and technologies more effectively, leading to better outcomes in their machine learning projects.
 tags:
-- Machine learning
-- Fundamentals
-- Tools
+- Machine Learning
 title: 'Machine Learning: Why Fundamentals Matter More Than Tools'
 ---
 

--- a/_posts/2024-09-04-moving_averages.md
+++ b/_posts/2024-09-04-moving_averages.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Behavioral Analysis
+- Data Science
 classes: wide
 date: '2024-09-04'
 header:
@@ -11,13 +11,14 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_8.jpg
   twitter_image: /assets/images/data_science_4.jpg
+redirect_from:
+- '/behavioral analysis/moving_averages/'
 seo_description: How moving averages reveal trends in human behavior far beyond stock trading, and how to tune them for behavioral data.
 seo_title: Moving Averages Beyond Financial Markets
 seo_type: article
 tags:
-- Moving averages
-- Behavioral patterns
-- Data analysis
+- Time Series
+- Data Analysis
 title: Using Moving Averages to Analyze Behavior Beyond Financial Markets
 ---
 

--- a/_posts/2024-09-04-outlier_detection.md
+++ b/_posts/2024-09-04-outlier_detection.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
 classes: wide
 date: '2024-09-04'
 excerpt: Explore the intricacies of outlier detection using distance metrics and metric
@@ -23,6 +22,8 @@ keywords:
 - Anomaly detection methods
 - Machine learning outlier techniques
 - Python
+redirect_from:
+- '/data science/machine learning/outlier_detection/'
 seo_description: Outlier detection in machine learning using distance metrics and metric learning, and how they improve anomaly detection accuracy.
 seo_title: Outlier Detection with Distance Metric Learning
 seo_type: article
@@ -31,11 +32,9 @@ summary: This comprehensive guide explores outlier detection using distance metr
   Forests and distance metric learning in identifying anomalies and improving detection
   accuracy in machine learning models.
 tags:
-- Outlier detection
-- Distance metrics
-- Random forest
-- Distance metric learning
-- Anomaly detection
+- Anomaly Detection
+- Mathematical Modeling
+- Decision Trees
 - Python
 title: 'Understanding Outlier Detection: A Deep Dive into Distance Metric Learning'
 ---

--- a/_posts/2024-09-05-detecting_drift.md
+++ b/_posts/2024-09-05-detecting_drift.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
 classes: wide
 date: '2024-09-05'
 excerpt: Explore the challenges of using traditional hypothesis testing for detecting
@@ -22,6 +21,8 @@ keywords:
 - Data monitoring in machine learning
 - Bayesian methods in data science
 - Model adaptation and data drift
+redirect_from:
+- '/data science/machine learning/detecting_drift/'
 seo_description: Why hypothesis testing falls short for detecting data drift, and how Bayesian probability offers a better framework for monitoring shifts.
 seo_title: 'Data Drift: Hypothesis Tests vs. Bayesian Methods'
 seo_type: article
@@ -30,11 +31,10 @@ summary: This article explores the limitations of using hypothesis testing to de
   alternative approach, offering a more flexible and adaptive method for monitoring
   data shifts and maintaining model performance.
 tags:
-- Data drift
-- Hypothesis testing
-- Bayesian probability
-- Data monitoring
-- Model adaptation
+- Data Drift
+- Hypothesis Testing
+- Bayesian Statistics
+- Model Monitoring
 title: 'The Limitations of Hypothesis Testing for Detecting Data Drift: A Bayesian
   Alternative'
 ---

--- a/_posts/2024-09-05-real_time_data_streaming.md
+++ b/_posts/2024-09-05-real_time_data_streaming.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Data Engineering
-- Real-time Processing
+- Programming
 classes: wide
 date: '2024-09-05'
 excerpt: Learn how to implement real-time data streaming using Python and Apache Kafka.
@@ -24,6 +23,8 @@ keywords:
 - Data engineering best practices
 - Bash
 - Python
+redirect_from:
+- '/data engineering/real-time processing/real_time_data_streaming/'
 seo_description: 'Real-time data streaming with Python and Apache Kafka: setup, core concepts, and best practices for efficient processing pipelines.'
 seo_title: Real-time Data Streaming with Python and Apache Kafka
 seo_type: article
@@ -32,12 +33,10 @@ summary: This article provides a comprehensive guide to implementing real-time d
   data efficiently, and manage real-time data pipelines in Python, with a focus on
   best practices for data engineering.
 tags:
-- Apache kafka
+- Data Engineering
 - Python
-- Data streaming
-- Real-time processing
-- Data pipelines
-- Bash
+- MLOps
+- Programming
 title: Real-time Data Streaming using Python and Kafka
 ---
 

--- a/_posts/2024-09-06-covariate_shift.md
+++ b/_posts/2024-09-06-covariate_shift.md
@@ -28,11 +28,9 @@ summary: This article covers strategies for managing covariate shifts in machine
   and implement feature engineering to address data drift and ensure continued model
   performance.
 tags:
-- Covariate shift
-- Model monitoring
-- Feature engineering
-- Model adaptation
-- Data drift
+- Data Drift
+- Model Monitoring
+- Feature Engineering
 title: Managing Covariate Shifts in Machine Learning Models
 ---
 

--- a/_posts/2024-09-06-normality.md
+++ b/_posts/2024-09-06-normality.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Science
-- Machine Learning
 classes: wide
 date: '2024-09-06'
 excerpt: Explore the complexity of real-world data distributions beyond the normal
@@ -23,6 +21,8 @@ keywords:
 - Central limit theorem applications
 - Extreme value theory
 - Statistical analysis beyond normality
+redirect_from:
+- '/statistics/data science/machine learning/normality/'
 seo_description: 'Real-world data distributions explained: heavy tails, the Central Limit Theorem, and Extreme Value Theory, and why they matter.'
 seo_title: 'Beyond Normal: Real-World Data Distributions'
 seo_type: article
@@ -31,12 +31,7 @@ summary: This article delves into the complexity of real-world data distribution
   and heavy-tailed distributions, the Central Limit Theorem, and the application of
   Extreme Value Theory in data analysis.
 tags:
-- Normal distribution
-- Central limit theorem
-- Log-normal distribution
-- Extreme value theory
-- Heavy-tailed distributions
-- Fisher-tippett-gnedenko theorem
+- Probability
 title: 'Beyond Normality: The Complexity of Real-World Data Distributions'
 ---
 

--- a/_posts/2024-09-06-sequential_detection_switches.md
+++ b/_posts/2024-09-06-sequential_detection_switches.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Machine Learning
-- Data Analysis
 classes: wide
 date: '2024-09-06'
 excerpt: Learn about sequential detection techniques for identifying switches in models
@@ -23,6 +21,8 @@ keywords:
 - Time-series analysis
 - Dynamic systems modeling
 - Model structure shifts
+redirect_from:
+- '/statistics/machine learning/data analysis/sequential_detection_switches/'
 seo_description: Sequential detection methods for identifying structural changes, and how to apply change-point detection to time-series data.
 seo_title: Detecting Structural Changes in Models
 seo_type: article
@@ -31,11 +31,10 @@ summary: This article explores sequential detection techniques used for identify
   detection and sequential analysis, particularly in time-series data and dynamic
   systems.
 tags:
-- Change-point detection
-- Sequential analysis
-- Structural change
-- Time-series data
-- Dynamic systems
+- Data Drift
+- Experimental Design
+- Time Series
+- Numerical Methods
 title: Sequential Detection of Switches in Models with Changing Structures
 ---
 

--- a/_posts/2024-09-07-energie_efficiency.md
+++ b/_posts/2024-09-07-energie_efficiency.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
-- Sustainability
 classes: wide
 date: '2024-09-07'
 excerpt: Explore how Python and machine learning can be applied to analyze and improve
@@ -24,6 +22,8 @@ keywords:
 - Sustainable building practices
 - Carbon footprint reduction
 - Python
+redirect_from:
+- '/data science/machine learning/sustainability/energie_efficiency/'
 seo_description: How to apply machine learning and Python to building energy efficiency analysis, optimizing usage and reducing environmental impact.
 seo_title: Building Energy Efficiency with Python and ML
 seo_type: article
@@ -32,11 +32,9 @@ summary: This article covers the application of Python and machine learning to a
   improving sustainability, and reducing carbon footprints, helping to create more
   energy-efficient structures.
 tags:
-- Energy efficiency
+- Climate and Environment
 - Python
-- Machine learning
-- Building analysis
-- Sustainability
+- Machine Learning
 title: Building Energy Efficiency Analysis with Python and Machine Learning
 ---
 

--- a/_posts/2024-09-08-nonparametric_tests.md
+++ b/_posts/2024-09-08-nonparametric_tests.md
@@ -32,14 +32,12 @@ summary: This article explores the broader landscape of nonparametric tests, foc
   quantile regression and highlights how these approaches are used for robust statistical
   analysis without strict distributional assumptions.
 tags:
-- Nonparametric tests
-- Quantile regression
-- Mann-whitney test
-- Robust statistical methods
+- Nonparametric Methods
+- Regression
+- Hypothesis Testing
+- Robust Statistics
 - R
-- Bash
-- Ruby
-- Python
+- Programming
 title: 'The Real Power of Nonparametric Tests: Beyond Mann-Whitney'
 ---
 

--- a/_posts/2024-09-09-kmeans.md
+++ b/_posts/2024-09-09-kmeans.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Data Science
 classes: wide
 date: '2024-09-09'
 excerpt: KMeans is widely used, but it's not always the best clustering algorithm
@@ -22,6 +21,8 @@ keywords:
 - Unsupervised learning techniques
 - Better clustering methods
 - Machine learning clustering
+redirect_from:
+- '/machine learning/data science/kmeans/'
 seo_description: 'Why KMeans isn''t always the best clustering choice, and how Gaussian Mixture Models and other algorithms can perform better.'
 seo_title: Alternatives to KMeans Clustering
 seo_type: article
@@ -30,11 +31,9 @@ summary: This article discusses the limitations of KMeans as a clustering algori
   techniques. It provides insights into when to move beyond KMeans for better performance
   in unsupervised learning tasks.
 tags:
-- Kmeans
-- Clustering algorithms
-- Gaussian mixture models
-- Unsupervised learning
-- Clustering alternatives
+- Clustering
+- Statistical Modeling
+- Unsupervised Learning
 title: If You Use KMeans All the Time, Read This
 ---
 

--- a/_posts/2024-09-10-wilcoxon.md
+++ b/_posts/2024-09-10-wilcoxon.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Analysis
 classes: wide
 date: '2024-09-10'
 excerpt: Learn about the Wilcoxon Signed-Rank Test, a robust non-parametric method
@@ -24,6 +23,8 @@ keywords:
 - Statistical analysis for outliers
 - R
 - Python
+redirect_from:
+- '/statistics/data analysis/wilcoxon/'
 seo_description: The Wilcoxon Signed-Rank Test, a non-parametric alternative to the paired t-test for skewed data, outliers, and small samples.
 seo_title: Wilcoxon Signed-Rank Test vs. Paired T-Test
 seo_type: article
@@ -32,11 +33,10 @@ summary: This article explores the Wilcoxon Signed-Rank Test, a non-parametric a
   when assumptions of normality are violated, such as with skewed data, outliers,
   or small sample sizes.
 tags:
-- Wilcoxon signed-rank test
-- Non-parametric tests
-- Paired t-test
-- Statistical analysis
-- Robust statistical methods
+- Hypothesis Testing
+- Nonparametric Methods
+- Statistical Modeling
+- Robust Statistics
 - R
 - Python
 title: 'Understanding the Wilcoxon Signed-Rank Test: A Non-Parametric Alternative

--- a/_posts/2024-09-11-cross_validation.md
+++ b/_posts/2024-09-11-cross_validation.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Data Science
 classes: wide
 date: '2024-09-11'
 excerpt: An exploration of cross-validation techniques in machine learning, focusing
@@ -22,6 +21,8 @@ keywords:
 - Preventing overfitting
 - Machine learning model validation
 - Data science methodologies
+redirect_from:
+- '/machine learning/data science/cross_validation/'
 seo_description: Explore various cross-validation techniques in machine learning,
   their importance, and how they help ensure robust model performance by minimizing
   overfitting.
@@ -32,11 +33,9 @@ summary: Cross-validation is a critical technique in machine learning for assess
   methods, including k-fold, stratified, and leave-one-out cross-validation, and discusses
   their role in building reliable and generalizable machine learning models.
 tags:
-- Cross-validation
-- Model evaluation
-- Machine learning
-- Data validation
-- Overfitting
+- Model Evaluation
+- Machine Learning
+- Regularization
 title: 'Cross-Validation Techniques: Ensuring Robust Model Performance'
 ---
 

--- a/_posts/2024-09-12-confusion_matrix_classification_metrics_complete_guide.md
+++ b/_posts/2024-09-12-confusion_matrix_classification_metrics_complete_guide.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- machine-learning
-- model-evaluation
+- Machine Learning
 classes: wide
 date: '2024-09-12'
 excerpt: A detailed guide on the confusion matrix and performance metrics in machine
@@ -21,6 +20,8 @@ keywords:
 - Classification metrics
 - Model evaluation
 - Threshold tuning
+redirect_from:
+- '/machine-learning/model-evaluation/confusion_matrix_classification_metrics_complete_guide/'
 seo_description: Understand the confusion matrix, key classification metrics like
   precision and recall, and when to use each based on real-world cost trade-offs.
 seo_title: 'Confusion Matrix: Metrics and Trade-Offs'
@@ -30,11 +31,8 @@ summary: This guide explores the confusion matrix, explains how to calculate acc
   metric based on the application context. Includes threshold tuning techniques and
   real-world case studies.
 tags:
-- Confusion-matrix
-- Precision
-- Recall
-- F1-score
-- Model-performance
+- Model Evaluation
+- Model Monitoring
 title: 'Confusion Matrix and Classification Metrics: A Complete Guide'
 ---
 

--- a/_posts/2024-09-12-importance_sampling.md
+++ b/_posts/2024-09-12-importance_sampling.md
@@ -36,15 +36,11 @@ summary: Importance Sampling is an advanced technique used to improve the effici
   resources on rare but impactful loss events, it enhances the accuracy of risk predictions,
   particularly when working with complex copula models.
 tags:
-- Importance sampling
-- Monte carlo simulation
-- Credit risk
-- Copula models
-- Portfolio risk
+- Monte Carlo
+- Finance
 - Python
 - R
-- Ruby
-- Rust
+- Programming
 title: Importance Sampling for Portfolio Credit Risk
 ---
 

--- a/_posts/2024-09-13-multi_colinearity.md
+++ b/_posts/2024-09-13-multi_colinearity.md
@@ -30,10 +30,8 @@ summary: Multicollinearity occurs when independent variables in a regression mod
   and discusses various techniques, such as variance inflation factor (VIF) and ridge
   regression, to detect and mitigate its effects.
 tags:
-- Multicollinearity
-- Regression analysis
-- Collinearity
-- Statistical modeling
+- Regression
+- Statistical Modeling
 title: 'Multicollinearity: A Comprehensive Exploration'
 ---
 

--- a/_posts/2024-09-14-ML_supply_chain.md
+++ b/_posts/2024-09-14-ML_supply_chain.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Supply Chain Management
-- Machine Learning
-- Operations Management
+- Economics
 classes: wide
 date: '2024-09-14'
 excerpt: Learn how machine learning optimizes supply chain operations by enhancing
@@ -24,6 +22,8 @@ keywords:
 - Logistics optimization
 - Operations management
 - Predictive analytics in supply chain
+redirect_from:
+- '/supply chain management/machine learning/operations management/ML_supply_chain/'
 seo_description: How machine learning optimizes supply chain operations through demand forecasting, inventory management, and logistics.
 seo_title: Machine Learning in the Supply Chain
 seo_type: article
@@ -33,10 +33,9 @@ summary: Machine learning is revolutionizing supply chain management by optimizi
   costs, and drive business value through data-driven decision-making in supply chain
   operations.
 tags:
-- Supply chain
-- Machine learning
+- Supply Chain
+- Machine Learning
 - Optimization
-- Operations
 title: Using Machine Learning to Optimize Supply Chain Operations
 ---
 

--- a/_posts/2024-09-15-forest_fiers.md
+++ b/_posts/2024-09-15-forest_fiers.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Environmental Management
-- Machine Learning
-- Disaster Management
+- Environment
 classes: wide
 date: '2024-09-15'
 excerpt: This article delves into the role of machine learning in managing forest
@@ -24,6 +22,8 @@ keywords:
 - Environmental protection
 - Disaster management
 - Forest fire detection in portugal
+redirect_from:
+- '/environmental management/machine learning/disaster management/forest_fiers/'
 seo_description: Explore how machine learning enhances forest fire management in Portugal,
   addressing early detection, risk assessment, and the impact of eucalyptus plantations.
 seo_title: Machine Learning and Forest Fires in Portugal
@@ -34,12 +34,9 @@ summary: Machine learning plays a vital role in improving forest fire management
   of eucalyptus forests, and how data-driven approaches are transforming fire prevention
   and control efforts.
 tags:
-- Forest fires
-- Machine learning
-- Environmental protection
-- Portugal
-- Wildfire risk assessment
-- Eucalyptus forests
+- Climate and Environment
+- Machine Learning
+- Risk Management
 title: 'Machine Learning and Forest Fires: The Case of Portugal'
 ---
 

--- a/_posts/2024-09-16-ml_forest_fires.md
+++ b/_posts/2024-09-16-ml_forest_fires.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Environmental Management
-- Machine Learning
-- Disaster Management
+- Environment
 classes: wide
 date: '2024-09-16'
 excerpt: Machine learning is revolutionizing forest fire management through advanced
@@ -27,13 +25,14 @@ keywords:
 - Ai for disaster response
 - Blockchain for environmental monitoring
 - Sustainable technologies for fire management
+redirect_from:
+- '/environmental management/machine learning/disaster management/ml_forest_fires/'
 seo_description: Advanced machine learning for forest fire management, including deep learning, big data, IoT, and ethical considerations.
 seo_title: Machine Learning in Forest Fire Management
 seo_type: article
 tags:
-- Forest fires
-- Machine learning
-- Environmental sustainability
+- Climate and Environment
+- Machine Learning
 title: Advanced Machine Learning Applications in Forest Fire Management
 ---
 

--- a/_posts/2024-09-17-feature_engenniring.md
+++ b/_posts/2024-09-17-feature_engenniring.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Data Science
 classes: wide
 date: '2024-09-17'
 excerpt: Feature engineering is crucial in machine learning, but it's easy to make
@@ -27,13 +26,15 @@ keywords:
 - Robust feature engineering
 - Data cleaning for machine learning
 - Python
+redirect_from:
+- '/machine learning/data science/feature_engenniring/'
 seo_description: Five common feature engineering mistakes, including data leakage and over-engineering, and how to avoid them.
 seo_title: 5 Common Feature Engineering Mistakes to Avoid
 seo_type: article
 tags:
-- Feature engineering
-- Data preprocessing
-- Machine learning
+- Feature Engineering
+- Data Quality
+- Machine Learning
 - Python
 title: 5 Common Mistakes in Feature Engineering and How to Avoid Them
 ---

--- a/_posts/2024-09-17-ml_healthcare.md
+++ b/_posts/2024-09-17-ml_healthcare.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Data Analytics
+- Data Science
 classes: wide
 date: '2024-09-17'
 excerpt: Discover how machine learning is revolutionizing healthcare analytics, from
@@ -26,6 +26,8 @@ keywords:
 - Clinical implementation challenges
 - Predictive patient outcomes
 - Real-time medical data analysis
+redirect_from:
+- '/data analytics/ml_healthcare/'
 seo_description: 'How machine learning is changing healthcare analytics: predictive patient outcomes, personalized medicine, and medical imaging.'
 seo_title: Machine Learning in Healthcare Analytics
 seo_type: article
@@ -38,12 +40,9 @@ summary: Machine learning is reshaping healthcare analytics by enabling advanced
   With its potential to enhance patient care and optimize resource allocation, machine
   learning is poised to revolutionize the healthcare industry.
 tags:
-- Healthcare analytics
-- Machine learning
-- Artificial intelligence
-- Medical imaging
-- Personalized medicine
-- Predictive analytics
+- Healthcare
+- Machine Learning
+- Artificial Intelligence
 title: How Machine Learning is Transforming Healthcare Analytics
 ---
 

--- a/_posts/2024-09-18-bayesian_statistics_machine_learning.md
+++ b/_posts/2024-09-18-bayesian_statistics_machine_learning.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Statistics
 classes: wide
 date: '2024-09-18'
 excerpt: Unlock the power of Bayesian statistics in machine learning through probabilistic
@@ -26,6 +25,8 @@ keywords:
 - Probabilistic programming
 - Bayesian networks
 - Uncertainty quantification
+redirect_from:
+- '/machine learning/statistics/bayesian_statistics_machine_learning/'
 seo_description: 'Bayesian statistics in machine learning: probabilistic reasoning, uncertainty quantification, and practical applications.'
 seo_title: Demystifying Bayesian Statistics in Machine Learning
 seo_type: article
@@ -39,9 +40,8 @@ summary: Bayesian statistics provides a powerful framework for dealing with unce
   guide offers valuable insights into the real-world applications of Bayesian statistics
   in AI.
 tags:
-- Bayesian statistics
-- Probabilistic reasoning
-- Artificial intelligence
+- Bayesian Statistics
+- Artificial Intelligence
 title: Demystifying Bayesian Statistics for Machine Learning
 ---
 

--- a/_posts/2024-09-19-build_ds_team.md
+++ b/_posts/2024-09-19-build_ds_team.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Team Management
-- Organizational Behavior
 classes: wide
 date: '2024-09-19'
 excerpt: Discover the implications of assigning different job titles in data science
@@ -27,6 +25,8 @@ keywords:
 - Career development
 - Employee motivation
 - Team management
+redirect_from:
+- '/data science/team management/organizational behavior/build_ds_team/'
 seo_description: The pros and cons of uniform versus specialized job titles in data science teams, and how they affect collaboration.
 seo_title: 'Job Titles in Data Science Teams: Uniform or Not'
 seo_type: article
@@ -40,16 +40,8 @@ summary: This article explores the debate on whether data science teams should a
   the article provides recommendations to help organizations make informed decisions
   that align with their strategic goals and foster a productive work environment.
 tags:
-- Data science teams
-- Job titles
-- Team dynamics
-- Software engineering
-- Machine learning research
-- Organizational culture
-- Team collaboration
-- Human resources
-- Career development
-- Employee motivation
+- Data Science
+- Machine Learning
 title: 'The Great Title Debate: Should Data Science Teams Assign Different Job Titles
   to Specialized Roles?'
 toc: false

--- a/_posts/2024-09-20-model_customer_behaviour.md
+++ b/_posts/2024-09-20-model_customer_behaviour.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Data Science
 classes: wide
 date: '2024-09-20'
 excerpt: Understand how Markov chains can be used to model customer behavior in cloud
@@ -26,6 +25,8 @@ keywords:
 - Customer behavior prediction
 - Data-driven decision-making
 - Python
+redirect_from:
+- '/machine learning/data science/model_customer_behaviour/'
 seo_description: How Markov chains model and predict customer behavior in cloud services, supporting data-driven retention strategies.
 seo_title: Modeling Cloud Customer Behavior with Markov Chains
 seo_type: article
@@ -38,11 +39,11 @@ summary: This article explores how Markov chains can be used to model customer b
   and practical applications, readers are introduced to the mechanics of Markov chains
   and their potential impact on cloud-based services.
 tags:
-- Cloud computing
-- Customer behavior
-- Markov chains
-- Data analysis
-- Predictive modeling
+- MLOps
+- Customer Analytics
+- Stochastic Processes
+- Data Analysis
+- Machine Learning
 - Python
 title: Deciphering Cloud Customer Behavior
 toc: false

--- a/_posts/2024-09-21-data_design.md
+++ b/_posts/2024-09-21-data_design.md
@@ -39,9 +39,9 @@ summary: Data quality is a crucial, yet often overlooked, aspect of data science
   guide covers key strategies for maintaining high-quality data across the lifecycle
   of any data-driven project.
 tags:
-- Data science
-- Data engineering
-- Data quality
+- Data Science
+- Data Engineering
+- Data Quality
 title: 'The Unseen Art of Data Quality: Bridging the Gap Between Collection and Utilization'
 ---
 

--- a/_posts/2024-09-21-data_drift_example.md
+++ b/_posts/2024-09-21-data_drift_example.md
@@ -36,10 +36,10 @@ summary: Data drift can significantly affect the accuracy of credit risk models,
   robustness of credit risk models, ensuring they remain effective over time despite
   changes in underlying data distributions.
 tags:
-- Credit risk modeling
-- Data drift
-- Machine learning
-- Multivariate analysis
+- Finance
+- Data Drift
+- Machine Learning
+- Multivariate Analysis
 title: Solving Data Drift Issues in Credit Risk Models
 ---
 

--- a/_posts/2024-09-22-randomized_inference.md
+++ b/_posts/2024-09-22-randomized_inference.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
 classes: wide
 date: '2024-09-22'
 excerpt: COPOD is a popular anomaly detection model, but how well does it perform
@@ -15,6 +14,8 @@ header:
   show_overlay_excerpt: false
   teaser: /assets/images/data_science_4.jpg
   twitter_image: /assets/images/data_science_1.jpg
+redirect_from:
+- '/data science/machine learning/randomized_inference/'
 seo_description: Learn the importance of validating anomaly detection models like
   COPOD. Explore the pitfalls of assuming variable independence in high-dimensional
   data.
@@ -28,9 +29,8 @@ summary: Anomaly detection models like COPOD are widely used, but proper validat
   best practices for model validation, helping data scientists avoid common mistakes
   and improve the robustness of their anomaly detection techniques.
 tags:
-- Anomaly detection
-- Model validation
-- Copod
+- Anomaly Detection
+- Model Monitoring
 - Python
 title: 'Validating Anomaly Detection Models: Lessons from COPOD'
 ---

--- a/_posts/2024-09-23-improving_decision_trees.md
+++ b/_posts/2024-09-23-improving_decision_trees.md
@@ -27,10 +27,9 @@ summary: This article explains how to enhance decision tree performance using Ge
   Algorithms. The approach allows for small, interpretable trees that outperform those
   created with standard greedy methods.
 tags:
-- Decision trees
-- Genetic algorithms
-- Interpretable ai
-- Classification models
+- Decision Trees
+- Machine Learning
+- Classification
 - Python
 title: Improving Decision Tree Performance with Genetic Algorithms
 ---

--- a/_posts/2024-09-24-sample_size_clinical.md
+++ b/_posts/2024-09-24-sample_size_clinical.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Clinical Research
-- Biostatistics
+- Healthcare
 classes: wide
 date: '2024-09-24'
 excerpt: A complete guide to writing the sample size justification section for your
@@ -21,6 +20,8 @@ keywords:
 - Statistical power
 - Type 1 and type 2 errors
 - Biostatistics in clinical research
+redirect_from:
+- '/clinical research/biostatistics/sample_size_clinical/'
 seo_description: Learn how to write a comprehensive sample size justification in your
   clinical protocol, ensuring adequate power and statistical rigor in your trial design.
 seo_title: Sample Size Justification for Clinical Protocols
@@ -34,11 +35,10 @@ summary: Proper sample size justification is a critical component of clinical tr
   standards while minimizing the risk of invalid results due to inadequate sample
   sizes.
 tags:
-- Sample size justification
-- Clinical protocol
-- Biostatistics
-- Clinical trial design
-- Statistical power
+- Sample Size
+- Healthcare
+- Statistical Modeling
+- Experimental Design
 title: How to Write the Sample Size Justification Section in Your Clinical Protocol
 ---
 

--- a/_posts/2024-09-25-simuled_anneling.md
+++ b/_posts/2024-09-25-simuled_anneling.md
@@ -31,11 +31,7 @@ summary: Simulated annealing is a probabilistic optimization technique inspired 
   find global solutions.
 tags:
 - Optimization
-- Simulated annealing
-- Algorithms
-- Hyperparameter tuning
-- Machine learning models
-- Non-convex optimization
+- Machine Learning
 - Python
 title: Optimizing Machine Learning Models using Simulated Annealing
 ---

--- a/_posts/2024-09-27-entropy_data_science.md
+++ b/_posts/2024-09-27-entropy_data_science.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
 classes: wide
 date: '2024-09-27'
 excerpt: Explore the deep connection between entropy, data science, and machine learning. Understand how entropy drives decision trees, uncertainty measures, feature selection, and information theory in modern AI.
@@ -25,17 +24,18 @@ keywords:
 - Data science
 - Machine learning
 - Python
+redirect_from:
+- '/data science/machine learning/entropy_data_science/'
 seo_description: The role entropy plays in data science and machine learning, from decision trees to uncertainty quantification and information theory.
 seo_title: Entropy in Data Science and Machine Learning
 seo_type: article
 summary: This article explores how entropy, a concept from information theory, is used in data science and machine learning. It delves into entropy’s role in decision trees, classification, clustering, anomaly detection, and reinforcement learning.
 tags:
-- Entropy
-- Information theory
-- Machine learning
-- Data science
-- Decision trees
 - Probability
+- Information Theory
+- Machine Learning
+- Data Science
+- Decision Trees
 - Python
 title: 'Entropy in Data Science and Machine Learning: A Deep Dive'
 ---

--- a/_posts/2024-09-28-rocauc.md
+++ b/_posts/2024-09-28-rocauc.md
@@ -24,10 +24,8 @@ seo_description: A deep dive into ROC AUC and Precision-Recall AUC, focusing on 
 seo_title: ROC AUC vs Precision-Recall AUC in Machine Learning
 seo_type: article
 tags:
-- Evaluation metrics
-- Roc auc
-- Precision-recall auc
-- Model performance
+- Model Evaluation
+- Model Monitoring
 title: Understanding the Differences Between ROC AUC and Precision-Recall AUC in Machine
   Learning
 toc: false

--- a/_posts/2024-09-29-business_intelligence_machine_learning.md
+++ b/_posts/2024-09-29-business_intelligence_machine_learning.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Business Intelligence
+- Economics
 classes: wide
 date: '2024-09-29'
 excerpt: The fusion of Business Intelligence and Machine Learning offers a pathway
@@ -18,6 +18,8 @@ keywords:
 - Machine learning
 - Data-driven decision making
 - Predictive analytics
+redirect_from:
+- '/business intelligence/business_intelligence_machine_learning/'
 seo_description: How integrating Business Intelligence and Machine Learning improves real-time decision-making, forecasting, and customer analysis.
 seo_title: Bridging Business Intelligence and Machine Learning
 seo_type: article
@@ -27,10 +29,8 @@ summary: This article examines the integration of Business Intelligence and Mach
   as forecasting, customer behavior analysis, and resource optimization, are discussed,
   along with practical examples from leading companies.
 tags:
-- Bi
-- Ml
-- Data analytics
-- Predictive analytics
+- Data Analysis
+- Machine Learning
 title: 'Bridging Business Intelligence and Machine Learning: A Strategic Imperative'
 ---
 

--- a/_posts/2024-09-29-causal_inference.md
+++ b/_posts/2024-09-29-causal_inference.md
@@ -35,9 +35,8 @@ summary: Monotonic constraints play a vital role in enhancing the reliability an
   businesses make more accurate and actionable predictions while maintaining transparency
   in their machine learning models.
 tags:
-- Causal ml
-- Monotonic constraints
-- Business applications
+- Correlation
+- Optimization
 - Python
 title: 'Causal Insights in Machine Learning: Monotonic Constraints for Better Predictions'
 ---

--- a/_posts/2024-09-30-ds_projects.md
+++ b/_posts/2024-09-30-ds_projects.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
 classes: wide
 date: '2024-09-30'
 excerpt: This checklist helps Data Science professionals ensure thorough validation
@@ -19,15 +18,15 @@ keywords:
 - Model deployment
 - Research validation
 - Best practices
+redirect_from:
+- '/data science/machine learning/ds_projects/'
 seo_description: A detailed checklist for Data Science professionals to validate research
   and model integrity before deployment.
 seo_title: Data Science Project Checklist Before Deployment
 seo_type: article
 tags:
-- Checklist
-- Model validation
-- Best practices
-- Deployment
+- Model Monitoring
+- MLOps
 title: 'Data Science Projects: Ensuring Success Before Deployment'
 toc: false
 toc_icon: check-circle

--- a/_posts/2024-09-30-exploratory_data_analysis_techniques_pandas.md
+++ b/_posts/2024-09-30-exploratory_data_analysis_techniques_pandas.md
@@ -26,8 +26,7 @@ summary: A comprehensive guide on Exploratory Data Analysis (EDA) using Pandas, 
   essential techniques for understanding, cleaning, and analyzing datasets in Python.
 tags:
 - Python
-- Pandas
-- Eda
+- Exploratory Data Analysis
 title: Exploratory Data Analysis (EDA) Techniques with Pandas
 ---
 

--- a/_posts/2024-10-01-automated_prompt_engineering.md
+++ b/_posts/2024-10-01-automated_prompt_engineering.md
@@ -28,10 +28,8 @@ summary: This article delves into Automated Prompt Engineering (APE), explaining
   it automates and optimizes the prompt generation process to enhance the performance
   of Large Language Models.
 tags:
-- Automated prompt engineering
-- Hyperparameter optimization
-- Prompt optimization
-- Large language models
+- Optimization
+- Natural Language Processing
 - Python
 title: 'Automated Prompt Engineering (APE): Optimizing Large Language Models through
   Automation'

--- a/_posts/2024-10-01-edge_machine_learning.md
+++ b/_posts/2024-10-01-edge_machine_learning.md
@@ -37,12 +37,9 @@ summary: This article explores how to implement continuous machine learning depl
   processing, lower latency, and improved decision-making in environments with limited
   connectivity.
 tags:
-- Mlops
-- Edge ai
-- Continuous deployment
-- Smart devices
-- Iot
-- Yaml
+- MLOps
+- Industrial IoT
+- Programming
 title: Implementing Continuous Machine Learning Deployment on Edge Devices
 ---
 

--- a/_posts/2024-10-02-building_data_driven_business_strategy.md
+++ b/_posts/2024-10-02-building_data_driven_business_strategy.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Business Intelligence
+- Economics
 classes: wide
 date: '2024-10-02'
 excerpt: A data-driven business strategy integrates Business Intelligence and Data
@@ -18,6 +18,8 @@ keywords:
 - Data science
 - Data-driven strategy
 - Predictive analytics
+redirect_from:
+- '/business intelligence/building_data_driven_business_strategy/'
 seo_description: How to build a data-driven business strategy by blending Business Intelligence and Data Science to improve decision-making.
 seo_title: Building a Data-Driven Business Strategy
 seo_type: article
@@ -27,10 +29,8 @@ summary: Discover how Business Intelligence and Data Science can work together t
   of companies like Walmart, Uber, and Netflix, and explore the necessary infrastructure
   to support a data-driven organization.
 tags:
-- Bi
-- Data science
-- Predictive analytics
-- Data strategy
+- Data Science
+- Machine Learning
 title: 'Building a Data-Driven Business Strategy: The Role of Business Intelligence
   and Data Science'
 ---

--- a/_posts/2024-10-03-differentiating_machine_learning_engineering_mlops.md
+++ b/_posts/2024-10-03-differentiating_machine_learning_engineering_mlops.md
@@ -29,10 +29,8 @@ summary: Machine Learning Engineering (MLE) and MLOps are two interconnected yet
   of both roles, highlighting where they overlap and where they diverge, especially
   in real-world machine learning projects.
 tags:
-- Machine learning engineering
-- Mlops
-- Ml infrastructure
-- Model deployment
+- Machine Learning
+- MLOps
 title: 'Differentiating Machine Learning Engineering and MLOps: A Fine Line Between
   Two Critical Roles'
 ---

--- a/_posts/2024-10-05-simple_distribution.md
+++ b/_posts/2024-10-05-simple_distribution.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time-Series
-- Machine Learning
+- Time Series
 classes: wide
 date: '2024-10-05'
 excerpt: An in-depth review of the role of simple distributional properties, like
@@ -18,6 +17,8 @@ keywords:
 - Time-series classification
 - Simple distributional properties
 - Deep learning
+redirect_from:
+- '/time-series/machine learning/simple_distribution/'
 seo_description: Explore the effectiveness of using simple distributional properties
   as a baseline for time-series classification, compared to complex deep learning
   models.
@@ -27,9 +28,8 @@ summary: This article reviews time-series classification techniques, highlightin
   the importance of simple distributional properties such as mean and standard deviation
   as a baseline.
 tags:
-- Time-series classification
-- Distributional properties
-- Deep learning
+- Time Series
+- Neural Networks
 title: A Comprehensive Review of Simple Distributional Properties as a Baseline for
   Time-Series Classification
 ---

--- a/_posts/2024-10-06-evaluating_distributions.md
+++ b/_posts/2024-10-06-evaluating_distributions.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time-Series
-- Machine Learning
+- Time Series
 classes: wide
 date: '2024-10-06'
 excerpt: A comprehensive review of simple distributional properties such as mean and
@@ -21,6 +20,8 @@ keywords:
 - Distributional properties
 - Machine learning
 - Benchmarking
+redirect_from:
+- '/time-series/machine learning/evaluating_distributions/'
 seo_description: How simple distributional properties perform in time-series classification benchmarks on the UEA/UCR repository.
 seo_title: Simple Baselines for Time-Series Classification
 seo_type: article
@@ -28,9 +29,7 @@ summary: This article discusses the use of simple distributional properties as a
   for time-series classification, focusing on benchmarks from the UEA/UCR repository
   and comparing simple and complex models.
 tags:
-- Time-series classification
-- Uea/ucr repository
-- Simple models
+- Time Series
 title: Evaluating Simple Distributional Properties for Time-Series Classification
   Benchmarks
 ---

--- a/_posts/2024-10-07-extending_simple_model.md
+++ b/_posts/2024-10-07-extending_simple_model.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time-Series
-- Machine Learning
+- Time Series
 classes: wide
 date: '2024-10-07'
 excerpt: Explore how simple distributional models for time-series classification can
@@ -20,6 +19,8 @@ keywords:
 - Catch22
 - Simple models
 - Feature engineering
+redirect_from:
+- '/time-series/machine learning/extending_simple_model/'
 seo_description: How simple time-series classification models can be extended with catch22 features, and the complexity-interpretability tradeoff.
 seo_title: Adding Catch22 to Time-Series Classification
 seo_type: article
@@ -27,9 +28,9 @@ summary: This article discusses when and how to extend simple time-series classi
   models by introducing additional features, such as catch22, and the practical implications
   of using these models in various domains.
 tags:
-- Time-series classification
-- Catch22
-- Feature engineering
+- Time Series
+- Machine Learning
+- Feature Engineering
 title: 'Extending Simple Models: The Role of Additional Features in Time-Series Classification'
 ---
 

--- a/_posts/2024-10-08-implementing_time_series.md
+++ b/_posts/2024-10-08-implementing_time_series.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time-Series
-- Machine Learning
+- Time Series
 classes: wide
 date: '2024-10-08'
 excerpt: Explore time-series classification in Python with step-by-step examples using
@@ -20,6 +19,8 @@ keywords:
 - Catch22
 - Python
 - Uea/ucr
+redirect_from:
+- '/time-series/machine learning/implementing_time_series/'
 seo_description: How to implement time-series classification in Python with simple models, catch22 features, and UEA/UCR benchmarking.
 seo_title: Time-Series Classification in Python with Catch22
 seo_type: article
@@ -28,9 +29,8 @@ summary: This article provides Python code for time-series classification, cover
   and statistical significance testing.
 tags:
 - Python
-- Time-series classification
-- Catch22
-- Uea/ucr
+- Time Series
+- Machine Learning
 title: 'Implementing Time-Series Classification: From Simple Models to Advanced Feature
   Sets'
 ---

--- a/_posts/2024-10-09-magnitude_matter_machine_learning.md
+++ b/_posts/2024-10-09-magnitude_matter_machine_learning.md
@@ -30,14 +30,12 @@ summary: This article discusses the importance of variable magnitude in machine 
   models, how feature scaling enhances model performance, and the distinctions between
   models that are sensitive to the scale of variables and those that are not.
 tags:
-- Feature scaling
-- Linear regression
-- Support vector machines
-- Neural networks
-- Knn
-- Pca
-- Random forests
-- Python
+- Feature Engineering
+- Regression
+- Classification
+- Neural Networks
+- Clustering
+- Dimensionality Reduction
 title: Does the Magnitude of the Variable Matter in Machine Learning?
 ---
 

--- a/_posts/2024-10-10-understanding_data_drift_what_why_matters_machine_learning.md
+++ b/_posts/2024-10-10-understanding_data_drift_what_why_matters_machine_learning.md
@@ -28,11 +28,8 @@ summary: This article explains the concept of data drift, focusing on how change
   types of data drift, such as covariate, label, and concept drift, providing examples
   from industries like finance and healthcare.
 tags:
-- Data drift
-- Machine learning models
-- Covariate drift
-- Concept drift
-- Label drift
+- Data Drift
+- Machine Learning
 title: 'Understanding Data Drift: What It Is and Why It Matters in Machine Learning'
 ---
 

--- a/_posts/2024-10-11-model_drift_why_even_best_machine_learning_models_fail_over_time.md
+++ b/_posts/2024-10-11-model_drift_why_even_best_machine_learning_models_fail_over_time.md
@@ -28,11 +28,9 @@ summary: This article examines model drift, focusing on how data drift, changes 
   over time. We explore the causes of model drift and provide case studies from industries
   like finance and healthcare.
 tags:
-- Model drift
-- Data drift
-- Machine learning models
-- Model degradation
-- Ai in production
+- Data Drift
+- Machine Learning
+- Model Monitoring
 title: 'Model Drift: Why Even the Best Machine Learning Models Fail Over Time'
 ---
 

--- a/_posts/2024-10-12-how_data_science_reshaping_business_strategy_age_machine_learning.md
+++ b/_posts/2024-10-12-how_data_science_reshaping_business_strategy_age_machine_learning.md
@@ -31,12 +31,10 @@ summary: This article examines how data science and machine learning are transfo
   approaches with data-driven methods and discusses the benefits of integrating data
   science into strategic planning.
 tags:
-- Data science
-- Machine learning
-- Business strategy
-- Customer segmentation
-- Churn prediction
-- Recommendation systems
+- Data Science
+- Machine Learning
+- Business Intelligence
+- Customer Analytics
 title: How Data Science is Reshaping Business Strategy in the Age of Machine Learning
 ---
 

--- a/_posts/2024-10-13-machine_learning_medical_diagnosis_enhancing_accuracy_speed.md
+++ b/_posts/2024-10-13-machine_learning_medical_diagnosis_enhancing_accuracy_speed.md
@@ -27,10 +27,9 @@ summary: This article explores the role of machine learning in improving the spe
   and accuracy of medical diagnosis, with a focus on CNNs and deep learning applications
   in detecting critical diseases.
 tags:
-- Medical diagnosis
-- Machine learning
-- Deep learning
-- Healthcare technology
+- Healthcare
+- Machine Learning
+- Neural Networks
 title: 'Machine Learning in Medical Diagnosis: Enhancing Accuracy and Speed'
 ---
 

--- a/_posts/2024-10-15-ttest_vs_ztest_when_why_use_each.md
+++ b/_posts/2024-10-15-ttest_vs_ztest_when_why_use_each.md
@@ -27,10 +27,8 @@ summary: A comprehensive guide to understanding the differences between t-tests 
   z-tests, covering when to use each test, their assumptions, and examples of one-sample,
   two-sample, and paired t-tests.
 tags:
-- T-test
-- Z-test
-- Hypothesis testing
-- Statistical analysis
+- Hypothesis Testing
+- Statistical Modeling
 title: 'T-Test vs. Z-Test: When and Why to Use Each'
 ---
 

--- a/_posts/2024-10-16-predictive_analytics_healthcare_anticipating_health_issues_before_they_happen.md
+++ b/_posts/2024-10-16-predictive_analytics_healthcare_anticipating_health_issues_before_they_happen.md
@@ -28,11 +28,9 @@ summary: This article provides an in-depth exploration of predictive analytics i
   to anticipate health problems before they arise, with a focus on hospital readmissions,
   disease outbreaks, and chronic disease management.
 tags:
-- Healthcare analytics
-- Predictive analytics
-- Data science
-- Machine learning
-- Chronic disease management
+- Healthcare
+- Machine Learning
+- Data Science
 title: 'Predictive Analytics in Healthcare: Anticipating Health Issues Before They
   Happen'
 ---

--- a/_posts/2024-10-17-natural_language_processing_nlp_healthcare_extracting_insights_unstructured_data.md
+++ b/_posts/2024-10-17-natural_language_processing_nlp_healthcare_extracting_insights_unstructured_data.md
@@ -27,11 +27,8 @@ tags:
 - Natural Language Processing
 - Healthcare
 - Machine Learning
-- Unstructured Data
-- Clinical Notes
 - Data Analysis
 - Data Science
-- null
 title: 'Natural Language Processing (NLP) in Healthcare: Extracting Insights from Unstructured Data'
 ---
 

--- a/_posts/2024-10-18-using_wearable_technology_big_data_health_monitoring.md
+++ b/_posts/2024-10-18-using_wearable_technology_big_data_health_monitoring.md
@@ -31,14 +31,11 @@ summary: This article explores the role of wearable technology and big data in h
   monitoring, examining how these tools support chronic disease management, early
   diagnosis, and preventive healthcare.
 tags:
-- Wearable technology
-- Big data
-- Health monitoring
-- Chronic disease
-- Preventive healthcare
-- Health analytics
-- Data science
-- Machine learning
+- Healthcare
+- Data Engineering
+- Model Monitoring
+- Data Science
+- Machine Learning
 title: Using Wearable Technology and Big Data for Health Monitoring
 ---
 

--- a/_posts/2024-10-19-datadriven_approaches_combating_antibiotic_resistance.md
+++ b/_posts/2024-10-19-datadriven_approaches_combating_antibiotic_resistance.md
@@ -28,10 +28,8 @@ summary: This article discusses how data science, through predictive modeling an
   pattern analysis, plays a crucial role in identifying misuse of antibiotics and
   proposing effective strategies to combat antibiotic resistance.
 tags:
-- Antibiotic resistance
-- Data science
-- Predictive modeling
-- Superbugs
+- Data Science
+- Machine Learning
 title: Data-Driven Approaches to Combating Antibiotic Resistance
 ---
 

--- a/_posts/2024-10-26-dynamic_systems_economics_understanding_changes_over_time.md
+++ b/_posts/2024-10-26-dynamic_systems_economics_understanding_changes_over_time.md
@@ -26,11 +26,8 @@ summary: Dynamic systems theory provides a framework for understanding how econo
   evolve over time, enabling economists to model complex interactions between variables
   and assess stability and change in macroeconomic conditions.
 tags:
-- Dynamic systems theory
-- Macroeconomics
-- Differential equations
-- Economic growth
-- Stability analysis
+- Economics
+- Numerical Methods
 title: 'Dynamic Systems in Economics: Understanding Changes Over Time'
 ---
 

--- a/_posts/2024-10-26-understanding_connection_between_correlation_covariance_standard_deviation.md
+++ b/_posts/2024-10-26-understanding_connection_between_correlation_covariance_standard_deviation.md
@@ -30,10 +30,8 @@ summary: Learn how correlation, covariance, and standard deviation are mathemati
   dependencies and variability in data.
 tags:
 - Correlation
-- Covariance
-- Standard deviation
-- Linear relationships
-- Mathematics
+- Descriptive Statistics
+- Mathematical Modeling
 - Statistics
 title: Understanding the Connection Between Correlation, Covariance, and Standard
   Deviation

--- a/_posts/2024-10-27-understanding_heteroscedasticity_statistics_data_science_machine_learning.md
+++ b/_posts/2024-10-27-understanding_heteroscedasticity_statistics_data_science_machine_learning.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Science
-- Machine Learning
 classes: wide
 date: '2024-10-27'
 excerpt: This in-depth guide explains heteroscedasticity in data analysis, highlighting
@@ -21,6 +19,8 @@ keywords:
 - Generalized least squares
 - Machine learning
 - Data science
+redirect_from:
+- '/statistics/data science/machine learning/understanding_heteroscedasticity_statistics_data_science_machine_learning/'
 seo_description: Explore heteroscedasticity, its forms, causes, detection methods,
   and solutions in statistical models, data science, and machine learning.
 seo_title: Comprehensive Guide to Heteroscedasticity in Data Analysis
@@ -29,9 +29,8 @@ summary: Heteroscedasticity complicates regression analysis by causing non-const
   variance in errors. Learn its types, causes, detection methods, and corrective techniques
   for robust data modeling.
 tags:
-- Heteroscedasticity
-- Regression analysis
-- Variance
+- Regression
+- Descriptive Statistics
 title: Understanding Heteroscedasticity in Statistics, Data Science, and Machine Learning
 ---
 

--- a/_posts/2024-10-28-understanding_normality_tests_deep_dive_into_their_power_limitations.md
+++ b/_posts/2024-10-28-understanding_normality_tests_deep_dive_into_their_power_limitations.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Data Analysis
+- Data Science
 classes: wide
 date: '2024-10-28'
 excerpt: An in-depth look at normality tests, their limitations, and the necessity
@@ -23,6 +23,8 @@ keywords:
 - Ruby
 - Scala
 - Go
+redirect_from:
+- '/data analysis/understanding_normality_tests_deep_dive_into_their_power_limitations/'
 seo_description: An in-depth exploration of normality tests, their limitations, and
   the importance of visual inspection for assessing whether data follow a normal distribution.
 seo_title: 'Understanding Normality Tests: A Deep Dive'
@@ -31,14 +33,12 @@ summary: This article delves into the intricacies of normality testing, revealin
   the limitations of common tests and emphasizing the importance of visual tools like
   QQ plots and CDF plots.
 tags:
-- Normality tests
-- Statistical methods
-- Data visualization
+- Hypothesis Testing
+- Statistical Modeling
+- Data Visualization
 - Python
 - R
-- Ruby
-- Scala
-- Go
+- Programming
 title: 'Understanding Normality Tests: A Deep Dive into Their Power and Limitations'
 ---
 

--- a/_posts/2024-10-29-exponential_smoothing_methods_time_series_forecasting.md
+++ b/_posts/2024-10-29-exponential_smoothing_methods_time_series_forecasting.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time Series Analysis
+- Time Series
 classes: wide
 date: '2024-10-29'
 excerpt: This detailed guide covers exponential smoothing methods for time series
@@ -24,6 +24,8 @@ keywords:
 - Inventory management
 - Python
 - R
+redirect_from:
+- '/time series analysis/exponential_smoothing_methods_time_series_forecasting/'
 seo_description: Simple, double, and triple exponential smoothing (ETS) for time series forecasting, how they compare to ARIMA, and where they apply.
 seo_title: Exponential Smoothing for Time Series Forecasting
 seo_type: article
@@ -32,11 +34,8 @@ summary: Explore the different types of exponential smoothing methods, how they 
   ETS methods with ARIMA models and includes use cases in retail, inventory management,
   and finance.
 tags:
-- Exponential smoothing
-- Ets
-- Time series forecasting
-- Forecasting models
-- Data science
+- Time Series
+- Data Science
 - Python
 - R
 title: Introduction to Exponential Smoothing Methods for Time Series Forecasting

--- a/_posts/2024-10-30-introduction_seasonal_decomposition_time_series.md
+++ b/_posts/2024-10-30-introduction_seasonal_decomposition_time_series.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Time Series Analysis
+- Time Series
 classes: wide
 date: '2024-10-30'
 excerpt: This article provides an in-depth look at STL and X-13-SEATS, two powerful
@@ -21,6 +21,8 @@ keywords:
 - Time series forecasting
 - R
 - Python
+redirect_from:
+- '/time series analysis/introduction_seasonal_decomposition_time_series/'
 seo_description: How STL and X-13-SEATS decomposition model seasonality in time series data, with practical examples in R and Python.
 seo_title: STL and X-13 Methods for Time Series Decomposition
 seo_type: article
@@ -29,10 +31,7 @@ summary: Explore STL (Seasonal-Trend decomposition using LOESS) and X-13-SEATS, 
   seasonality. The article includes practical examples and code implementation in
   both R and Python.
 tags:
-- Seasonal decomposition
-- Time series
-- Stl
-- X-13-seats
+- Time Series
 - Forecasting
 - Python
 - R

--- a/_posts/2024-10-31-machine_learning_fall_prediction.md
+++ b/_posts/2024-10-31-machine_learning_fall_prediction.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- HealthTech
+- Data Science
 classes: wide
 date: '2024-10-31'
 excerpt: Machine learning is revolutionizing fall prevention in elderly care by predicting
@@ -20,6 +20,8 @@ keywords:
 - Wearable technology
 - Elderly care
 - Health monitoring
+redirect_from:
+- '/healthtech/machine_learning_fall_prediction/'
 seo_description: Learn how machine learning models are used to predict and prevent
   falls among the elderly by analyzing sensor data, wearables, and health history.
 seo_title: Machine Learning for Fall Prevention in the Elderly
@@ -29,10 +31,8 @@ summary: Falls among the elderly are a significant public health concern. Machin
   and other health records, offering timely interventions that can improve quality
   of life.
 tags:
-- Machine learning
+- Machine Learning
 - Healthcare
-- Elderly care
-- Wearable technology
 title: Using Machine Learning to Predict and Prevent Falls in the Elderly
 ---
 

--- a/_posts/2024-11-01-data_driven_elderly_care.md
+++ b/_posts/2024-11-01-data_driven_elderly_care.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- HealthTech
+- Data Science
 classes: wide
 date: '2024-11-01'
 excerpt: Data science is revolutionizing chronic disease management among the elderly
@@ -20,6 +20,8 @@ keywords:
 - Elderly care
 - Data-driven healthcare
 - Personalized medicine
+redirect_from:
+- '/healthtech/data_driven_elderly_care/'
 seo_description: How predictive analytics helps manage chronic diseases such as diabetes, arthritis, and cardiovascular conditions in older adults.
 seo_title: Data Science for Managing Chronic Diseases in the Elderly
 seo_type: article
@@ -28,10 +30,8 @@ summary: Data-driven approaches are improving the management of chronic diseases
   allow healthcare providers to monitor disease progression, optimize medication regimens,
   and tailor treatment plans based on real-time individual health data.
 tags:
-- Chronic disease management
-- Predictive analytics
-- Elderly care
-- Healthcare technology
+- Healthcare
+- Machine Learning
 title: Data-Driven Approaches to Managing Chronic Diseases in the Elderly
 ---
 

--- a/_posts/2024-11-12-grubbs_test_comprehensive_guide_detecting_outliers.md
+++ b/_posts/2024-11-12-grubbs_test_comprehensive_guide_detecting_outliers.md
@@ -29,12 +29,10 @@ summary: Grubbs' test, also known as the extreme studentized deviate test, is a 
   tool for detecting outliers in normally distributed univariate data. This article
   covers its principles, assumptions, test procedure, and real-world applications.
 tags:
-- Grubbs' test
-- Outlier detection
-- Statistical methods
-- Extreme studentized deviate test
-- Hypothesis testing
-- Data analysis
+- Anomaly Detection
+- Statistical Modeling
+- Hypothesis Testing
+- Data Analysis
 - Python
 title: 'Grubbs'' Test: A Comprehensive Guide to Detecting Outliers'
 ---

--- a/_posts/2024-11-15-critical_examination_bayesian_posteriors_test_statistics.md
+++ b/_posts/2024-11-15-critical_examination_bayesian_posteriors_test_statistics.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Bayesian Inference
 classes: wide
 date: '2024-11-15'
 excerpt: This article critically examines the use of Bayesian posterior distributions
@@ -23,6 +22,8 @@ keywords:
 - R
 - Scala
 - Go
+redirect_from:
+- '/statistics/bayesian inference/critical_examination_bayesian_posteriors_test_statistics/'
 seo_description: A critical examination of Bayesian posteriors as test statistics,
   exploring their utility and limitations in statistical inference.
 seo_title: Bayesian Posteriors as Test Statistics
@@ -30,13 +31,12 @@ seo_type: article
 summary: An in-depth analysis of Bayesian posteriors as test statistics, examining
   their practical utility, sufficiency, and the challenges in interpreting them.
 tags:
-- Bayesian posteriors
-- Test statistics
-- Likelihoods
+- Bayesian Statistics
+- Hypothesis Testing
+- Probability
 - Python
 - R
-- Scala
-- Go
+- Programming
 title: A Critical Examination of Bayesian Posteriors as Test Statistics
 ---
 

--- a/_posts/2024-11-16-ensemble_learning_theory_techniques_applications.md
+++ b/_posts/2024-11-16-ensemble_learning_theory_techniques_applications.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- machine-learning
-- model-combination
+- Machine Learning
 classes: wide
 date: '2024-11-16'
 excerpt: Ensemble methods combine multiple models to improve accuracy, robustness,
@@ -22,6 +21,8 @@ keywords:
 - Stacking
 - Random forest
 - Xgboost
+redirect_from:
+- '/machine-learning/model-combination/ensemble_learning_theory_techniques_applications/'
 seo_description: 'Ensemble learning explained: how bagging, boosting, and stacking work, when to use them, and their real-world applications.'
 seo_title: 'Ensemble Methods: Bagging, Boosting, and Stacking'
 seo_type: article
@@ -29,13 +30,8 @@ summary: Ensemble learning leverages multiple models to enhance predictive perfo
   This article explores the motivations, techniques, theoretical insights, and applications
   of ensemble methods including bagging, boosting, and stacking.
 tags:
-- Ensemble-learning
-- Bagging
-- Boosting
-- Stacking
-- Random-forest
-- Xgboost
-- Model-interpretability
+- Decision Trees
+- Machine Learning
 title: 'Ensemble Learning: Theory, Techniques, and Applications'
 ---
 

--- a/_posts/2024-11-30-outliers.md
+++ b/_posts/2024-11-30-outliers.md
@@ -34,18 +34,12 @@ summary: This article delves deep into the topic of outliers in data analysis, c
   measurement errors, identify extreme observations, and apply techniques like mixture
   models and robust statistics for accurate analysis.
 tags:
-- Outliers
-- Robust statistics
-- Data analysis
-- Measurement error
-- Heavy-tailed distributions
-- Mixture models
-- Extreme observations
-- Novelty detection
-- Box plots
-- Statistical methods
-- Data science
-- Mathematics
+- Anomaly Detection
+- Robust Statistics
+- Data Analysis
+- Data Quality
+- Probability
+- Statistical Modeling
 title: 'Outliers: A Detailed Explanation'
 ---
 

--- a/_posts/2024-12-01-remote_monitoring_elderly_care.md
+++ b/_posts/2024-12-01-remote_monitoring_elderly_care.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- HealthTech
+- Data Science
 classes: wide
 date: '2024-12-01'
 excerpt: The integration of IoT and big data is revolutionizing elderly care by enabling
@@ -20,6 +20,8 @@ keywords:
 - Elderly care
 - Health emergencies
 - Smart homes
+redirect_from:
+- '/healthtech/remote_monitoring_elderly_care/'
 seo_description: How IoT devices, wearables, and health monitors use big data to remotely monitor older adults and detect emergencies in real time.
 seo_title: IoT and Big Data in Remote Monitoring for Elderly Care
 seo_type: article
@@ -28,11 +30,10 @@ summary: IoT-enabled devices and big data are transforming elderly care by enabl
   technologies offer continuous health tracking and quick responses to emergencies
   like heart attacks, strokes, or falls, ensuring that seniors remain safe and healthy.
 tags:
-- Elderly care
-- Iot
-- Big data
-- Remote monitoring
-- Health monitoring
+- Healthcare
+- Industrial IoT
+- Data Engineering
+- Model Monitoring
 title: 'Remote Monitoring and Elderly Care: How IoT and Big Data are Keeping Seniors
   Safe'
 ---

--- a/_posts/2024-12-03-dixon_q_test_guide_detecting_outliers.md
+++ b/_posts/2024-12-03-dixon_q_test_guide_detecting_outliers.md
@@ -31,11 +31,10 @@ summary: Dixon's Q test is a statistical tool designed for detecting outliers in
   the Q statistic, compare it to reference Q values, and effectively detect outliers
   using the test.
 tags:
-- Dixon's q test
-- Outlier detection
-- Statistical methods
-- Hypothesis testing
-- Data analysis
+- Anomaly Detection
+- Statistical Modeling
+- Hypothesis Testing
+- Data Analysis
 - Python
 title: 'Dixon''s Q Test: A Guide for Detecting Outliers'
 ---

--- a/_posts/2024-12-07-peirce_criterion_robust_method_detecting_outliers.md
+++ b/_posts/2024-12-07-peirce_criterion_robust_method_detecting_outliers.md
@@ -30,11 +30,10 @@ summary: Peirce's Criterion is a robust statistical tool for detecting and remov
   and its advantages in ensuring data integrity. Learn how to apply this method to
   improve the accuracy and reliability of your statistical analyses.
 tags:
-- Peirce's criterion
-- Outlier detection
-- Robust statistics
-- Hypothesis testing
-- Data analysis
+- Anomaly Detection
+- Robust Statistics
+- Hypothesis Testing
+- Data Analysis
 - R
 title: 'Peirce''s Criterion: A Robust Method for Detecting Outliers'
 ---

--- a/_posts/2024-12-08-exploring_kernel_density_estimation_powerful_tool_data_analysis.md
+++ b/_posts/2024-12-08-exploring_kernel_density_estimation_powerful_tool_data_analysis.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Machine Learning
-- Statistics
 classes: wide
 date: '2024-12-08'
 excerpt: Kernel Density Estimation (KDE) is a non-parametric technique offering flexibility
@@ -24,6 +22,8 @@ keywords:
 - High-dimensional data analysis
 - Python
 - R
+redirect_from:
+- '/data science/machine learning/statistics/exploring_kernel_density_estimation_powerful_tool_data_analysis/'
 seo_description: 'Kernel Density Estimation (KDE) explained: core concepts, applications, and advantages in machine learning and statistics.'
 seo_title: A Guide to Kernel Density Estimation
 seo_type: article
@@ -32,12 +32,10 @@ summary: Kernel Density Estimation (KDE) is a non-parametric technique for estim
   assuming predefined distributions. This article explores its concepts, applications,
   and techniques.
 tags:
-- Kernel density estimation
-- Kde
-- Density estimation
-- Non-parametric methods
-- Machine learning
-- Statistical analysis
+- Statistical Modeling
+- Mathematical Modeling
+- Nonparametric Methods
+- Machine Learning
 - Python
 - R
 title: 'Exploring Kernel Density Estimation: A Powerful Tool for Data Analysis'

--- a/_posts/2024-12-12-chauvenet_criterion_statistical_approach_detecting_outliers.md
+++ b/_posts/2024-12-12-chauvenet_criterion_statistical_approach_detecting_outliers.md
@@ -32,11 +32,10 @@ summary: Chauvenet's Criterion is a robust statistical method for identifying ou
   deviations, assess probability thresholds, and use the criterion to improve the
   quality of your data analysis.
 tags:
-- Chauvenet's criterion
-- Outlier detection
-- Statistical methods
-- Hypothesis testing
-- Data analysis
+- Anomaly Detection
+- Statistical Modeling
+- Hypothesis Testing
+- Data Analysis
 - Python
 - R
 title: 'Chauvenet''s Criterion: A Statistical Approach to Detecting Outliers'

--- a/_posts/2024-12-25-linear_optimization_efficient_resource_allocation_business_success.md
+++ b/_posts/2024-12-25-linear_optimization_efficient_resource_allocation_business_success.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Operations Research
-- Data Science
-- Business Analytics
+- Economics
 classes: wide
 date: '2024-12-25'
 excerpt: Learn how decision-makers in industries like logistics, finance, and manufacturing
@@ -24,6 +22,8 @@ keywords:
 - Resource allocation
 - R
 - Python
+redirect_from:
+- '/operations research/data science/business analytics/linear_optimization_efficient_resource_allocation_business_success/'
 seo_description: 'Linear optimization explained: key components, simplex and graphical methods, and applications in finance, logistics, and production.'
 seo_title: Comprehensive Guide to Linear Optimization for Business
 seo_type: article
@@ -32,12 +32,8 @@ summary: This article provides an in-depth look at linear optimization, includin
   with methods such as the Simplex and Graphical methods. Practical examples highlight
   its applications in finance, logistics, and production.
 tags:
-- Linear optimization
-- Operations research
-- Resource allocation
-- Business analytics
-- Decision making
-- Linear programming
+- Optimization
+- Business Intelligence
 - R
 - Python
 title: 'Linear Optimization: Efficient Resource Allocation for Business Success'

--- a/_posts/2024-12-30-predicting_hospital_readmissions.md
+++ b/_posts/2024-12-30-predicting_hospital_readmissions.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- HealthTech
+- Data Science
 classes: wide
 date: '2024-12-30'
 excerpt: Machine learning models are revolutionizing post-hospitalization care by
@@ -20,6 +20,8 @@ keywords:
 - Elderly patients
 - Post-hospital care
 - Predictive analytics
+redirect_from:
+- '/healthtech/predicting_hospital_readmissions/'
 seo_description: How machine learning predicts hospital readmissions in elderly patients using post-discharge data, adherence, and health conditions.
 seo_title: Predicting Hospital Readmissions with ML
 seo_type: article
@@ -28,10 +30,8 @@ summary: Hospital readmissions among elderly patients are a significant healthca
   to predict readmission risks by analyzing post-discharge data, health records, and
   treatment adherence, enabling optimized care and timely interventions.
 tags:
-- Hospital readmissions
-- Predictive analytics
-- Elderly care
-- Healthcare ai
+- Machine Learning
+- Healthcare
 title: Predicting Hospital Readmissions for Elderly Patients Using Machine Learning
 ---
 

--- a/_posts/2024-12-31-multiagent_collaboration_finance_building_intelligent_teams_llms.md
+++ b/_posts/2024-12-31-multiagent_collaboration_finance_building_intelligent_teams_llms.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Finance
-- Artificial Intelligence
-- Multi-Agent Systems
+- Economics
 classes: wide
 date: '2024-12-31'
 excerpt: Multi-agent systems are redefining how financial tasks like M&A analysis can be approached, using teams of collaborative LLMs with distinct responsibilities.
@@ -20,16 +18,15 @@ keywords:
 - AutoGen
 - M&A analysis
 - CrewAI
+redirect_from:
+- '/finance/artificial intelligence/multi-agent systems/multiagent_collaboration_finance_building_intelligent_teams_llms/'
 seo_description: 'How multi-agent LLM systems like AutoGen, CrewAI, and OpenDevin simulate analyst, compliance, and auditor roles in M&A analysis.'
 seo_title: Multi-Agent Collaboration in Finance with LLMs
 seo_type: article
 summary: This article explores the rise of multi-agent architectures in finance, using tools like AutoGen and CrewAI to simulate collaborative roles in tasks like M&A, compliance review, and financial reporting.
 tags:
-- LLM agents
-- AutoGen
-- CrewAI
-- Financial automation
-- M&A analysis
+- Natural Language Processing
+- MLOps
 title: 'Multi-Agent Collaboration in Finance: Building Intelligent Teams with LLMs'
 ---
 

--- a/_posts/2025-01-01-understanding_statistical_significance_data_analysis.md
+++ b/_posts/2025-01-01-understanding_statistical_significance_data_analysis.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Data Science
-- Statistics
 classes: wide
 date: '2025-01-01'
 excerpt: Learn the essential concepts of statistical significance and how it applies
@@ -20,6 +19,8 @@ keywords:
 - Inferential statistics
 - Data analysis
 - Business analytics
+redirect_from:
+- '/data science/statistics/understanding_statistical_significance_data_analysis/'
 seo_description: 'Statistical significance explained: hypothesis testing, p-values, confidence intervals, and their role in data-driven decisions.'
 seo_title: Statistical Significance in Data Analysis
 seo_type: article
@@ -27,12 +28,10 @@ summary: This article provides a detailed exploration of statistical significanc
   covering key topics like hypothesis testing, p-values, confidence intervals, and
   their applications in business and data analysis.
 tags:
-- Statistical significance
-- Hypothesis testing
-- Inferential statistics
-- P-values
-- Confidence intervals
-- Business analytics
+- Hypothesis Testing
+- Descriptive Statistics
+- Confidence Intervals
+- Business Intelligence
 title: Understanding Statistical Significance in Data Analysis
 ---
 

--- a/_posts/2025-01-02-bayesian_state_space_models_macroeconometrics.md
+++ b/_posts/2025-01-02-bayesian_state_space_models_macroeconometrics.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Macroeconometrics
+- Data Science
 classes: wide
 date: '2025-01-02'
 excerpt: Explore the critical role of Bayesian state space models in macroeconometric
@@ -20,6 +20,8 @@ keywords:
 - Kalman filter
 - State space models
 - Particle filtering
+redirect_from:
+- '/macroeconometrics/bayesian_state_space_models_macroeconometrics/'
 seo_description: 'Bayesian state space models in macroeconometrics: their applications, estimation techniques, and handling of large datasets.'
 seo_title: Bayesian State Space Models in Macroeconometrics
 seo_type: article
@@ -27,10 +29,9 @@ summary: This article provides an in-depth explanation of Bayesian state space m
   in macroeconometrics, covering estimation techniques, high-dimensional data challenges,
   and advanced approaches to non-linear and non-Gaussian models.
 tags:
-- Bayesian methods
-- State space models
-- Time series
-- Macroeconomics
+- Bayesian Statistics
+- Time Series
+- Economics
 title: Bayesian State Space Models in Macroeconometrics
 ---
 

--- a/_posts/2025-01-07-elderly_mental_health_machine_learning_data_analytics.md
+++ b/_posts/2025-01-07-elderly_mental_health_machine_learning_data_analytics.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Healthcare
-- Machine Learning
-- Mental Health
 classes: wide
 date: '2025-01-07'
 excerpt: Machine learning is reshaping elderly mental health care. This article explores
@@ -22,6 +20,8 @@ keywords:
 - Machine learning depression detection
 - Cognitive decline prediction
 - Health analytics for seniors
+redirect_from:
+- '/healthcare/machine learning/mental health/elderly_mental_health_machine_learning_data_analytics/'
 seo_description: How machine learning and analytics support elderly mental health care through early detection of depression, anxiety, and dementia.
 seo_title: AI and Analytics in Elderly Mental Health
 seo_type: article
@@ -29,12 +29,8 @@ summary: This article discusses how AI and data analytics are improving mental h
   outcomes in the elderly population. It covers use cases like AI-powered mood monitoring,
   behavioral tracking, and early intervention tools for dementia and depression.
 tags:
-- Elderly care
-- Mental health
-- Ai in healthcare
-- Cognitive decline
-- Depression
-- Data analytics
+- Healthcare
+- Data Analysis
 title: Improving Elderly Mental Health with Machine Learning and Data Analytics
 ---
 

--- a/_posts/2025-01-18-differential_equations_growth_models.md
+++ b/_posts/2025-01-18-differential_equations_growth_models.md
@@ -24,10 +24,8 @@ seo_title: Differential Equations in Economic Growth Models
 seo_type: article
 summary: A comprehensive discussion of how differential equations are applied in macroeconomic growth models, with a special focus on the Solow and Romer growth models, dynamic systems, and optimal control theory.
 tags:
-- Economic Growth
-- Differential Equations
-- Solow Growth Model
-- Romer Endogenous Growth Model
+- Economics
+- Numerical Methods
 title: Differential Equations in Growth Models
 ---
 

--- a/_posts/2025-01-31-nonlinear_growth_models_macroeconomics.md
+++ b/_posts/2025-01-31-nonlinear_growth_models_macroeconomics.md
@@ -1,8 +1,7 @@
 ---
 author_profile: false
 categories:
-- Macroeconomics
-- Economic Modeling
+- Economics
 classes: wide
 date: '2025-01-31'
 excerpt: Nonlinear growth models offer a richer and more realistic framework for understanding
@@ -21,6 +20,8 @@ keywords:
 - Economic growth theory
 - Endogenous growth
 - Differential equations
+redirect_from:
+- '/macroeconomics/economic modeling/nonlinear_growth_models_macroeconomics/'
 seo_description: Explore how nonlinearities shape long-term economic growth and stability,
   from endogenous feedback effects to bifurcations in policy-driven growth models.
 seo_title: Nonlinear Growth Models in Macroeconomics
@@ -29,11 +30,7 @@ summary: This article explores the emergence and importance of non-linear dynami
   in macroeconomic growth models, highlighting key mechanisms, implications for long-term
   development, and policy design.
 tags:
-- Nonlinear dynamics
-- Economic growth
-- Solow model
-- Endogenous growth
-- Phase transitions
+- Economics
 title: Nonlinear Growth Models in Macroeconomics
 ---
 

--- a/_posts/2025-02-02-time_series_forecasting_sarima_seasonal_arima_explained.md
+++ b/_posts/2025-02-02-time_series_forecasting_sarima_seasonal_arima_explained.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Time Series
-- Forecasting
-- Data Science
 classes: wide
 date: '2025-02-02'
 excerpt: This in-depth guide explores Seasonal ARIMA (SARIMA) for forecasting time
@@ -25,6 +23,8 @@ keywords:
 - Seasonal time series
 - Python
 - Bash
+redirect_from:
+- '/time series/forecasting/data science/time_series_forecasting_sarima_seasonal_arima_explained/'
 seo_description: How SARIMA extends ARIMA to handle seasonality in forecasting, covering model selection, parameters, and Python implementation.
 seo_title: 'SARIMA: Seasonal ARIMA Forecasting Explained'
 seo_type: article
@@ -32,13 +32,9 @@ summary: SARIMA is an extension of ARIMA that models seasonality, a crucial feat
   in many real-world time series. This article explains the theory, model structure,
   parameter tuning, and offers complete implementation guides using Python.
 tags:
-- Time series analysis
-- Sarima
-- Arima
-- Forecasting models
+- Time Series
 - Python
-- Seasonality
-- Bash
+- Programming
 title: 'Time Series Forecasting with SARIMA: Seasonal ARIMA Explained'
 ---
 

--- a/_posts/2025-02-17-handling_non-stationarity_time_series_data.md
+++ b/_posts/2025-02-17-handling_non-stationarity_time_series_data.md
@@ -1,15 +1,12 @@
 ---
+redirect_from:
+- '/time series/data science/forecasting/handling_non-stationarity_time_series_data/'
 title: "Handling Non-Stationarity in Time Series Data: Techniques and Best Practices"
 categories:
 - Time Series
-- Data Science
-- Forecasting
 tags:
-- non-stationary data
-- time series analysis
-- ADF test
-- KPSS test
-- data transformation
+- Time Series
+- Feature Engineering
 author_profile: false
 seo_title: "Handling Non-Stationarity in Time Series Data"
 seo_description: "Learn how to detect and handle non-stationary time series using statistical tests, transformations, and modeling techniques to build robust forecasting models."

--- a/_posts/2025-03-01-the_impossible_dream_regression_confidence_bands.md
+++ b/_posts/2025-03-01-the_impossible_dream_regression_confidence_bands.md
@@ -1,16 +1,15 @@
 ---
+redirect_from:
+- '/statistics/regression/uncertainty-quantification/the_impossible_dream_regression_confidence_bands/'
 title: "The Impossible Dream: Why Regression Confidence Bands Can't Exist Without Assumptions"
 categories:
-- statistics
-- regression
-- uncertainty-quantification
+- Statistics
 
 tags:
-- confidence-intervals
-- nonparametric-regression
-- statistical-inference
-- assumptions
-- conformal-prediction
+- Confidence Intervals
+- Nonparametric Methods
+- Statistical Modeling
+- Model Evaluation
 
 author_profile: false
 seo_title: Why Regression Confidence Bands Need Assumptions

--- a/_posts/2025-04-18-monte_carlo_simulations_macroeconomic_modeling.md
+++ b/_posts/2025-04-18-monte_carlo_simulations_macroeconomic_modeling.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Macroeconomics
-- Simulation Methods
-- Quantitative Finance
+- Economics
 classes: wide
 date: '2025-04-18'
 excerpt: Monte Carlo simulations offer a powerful way to model uncertainty in macroeconomic
@@ -23,6 +21,8 @@ keywords:
 - Policy modeling
 - Forecasting methods
 - Python
+redirect_from:
+- '/macroeconomics/simulation methods/quantitative finance/monte_carlo_simulations_macroeconomic_modeling/'
 seo_description: How Monte Carlo methods simulate uncertainty, test policy scenarios, and improve macroeconomic forecasting with stochastic techniques.
 seo_title: Monte Carlo Simulations in Macroeconomics
 seo_type: article
@@ -30,11 +30,9 @@ summary: This article explores the role of Monte Carlo simulation methods in mac
   modeling, covering their mathematical basis, implementation, and real-world applications
   in policy, forecasting, and risk management.
 tags:
-- Monte carlo
-- Economic forecasting
-- Uncertainty modeling
-- Probabilistic simulations
-- Computational economics
+- Monte Carlo
+- Economics
+- Confidence Intervals
 - Python
 title: Monte Carlo Simulations in Macroeconomic Modeling
 ---

--- a/_posts/2025-04-25-case_study_how_llm_agent_streamlines_quarterly_earnings_calls_analysts.md
+++ b/_posts/2025-04-25-case_study_how_llm_agent_streamlines_quarterly_earnings_calls_analysts.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Finance
-- Natural Language Processing
-- Case Study
+- Economics
 classes: wide
 date: '2025-04-25'
 excerpt: This case study shows how an LLM-powered agent automates the analysis of earnings call transcripts—summarizing key points, extracting financial guidance, and improving analyst productivity.
@@ -21,17 +19,16 @@ keywords:
 - OpenAI
 - Financial text analysis
 - python
+redirect_from:
+- '/finance/natural language processing/case study/case_study_how_llm_agent_streamlines_quarterly_earnings_calls_analysts/'
 seo_description: Explore how large language model agents can automate and streamline the analysis of quarterly earnings calls for financial analysts using OpenAI and LangChain.
 seo_title: LLM Agents for Automated Earnings Call Analysis
 seo_type: article
 summary: Learn how an LLM agent built with LangChain and OpenAI API can extract financial guidance, sentiment, and KPIs from quarterly earnings call transcripts, automating a time-consuming task for financial analysts.
 tags:
-- LLM agents
-- Earnings call analysis
-- Financial automation
-- LangChain
-- OpenAI
-- python
+- Natural Language Processing
+- MLOps
+- Python
 title: 'Case Study: How an LLM Agent Streamlines Quarterly Earnings Calls for Analysts'
 ---
 

--- a/_posts/2025-04-27-introduction_predictive_maintenance_industrial_operations.md
+++ b/_posts/2025-04-27-introduction_predictive_maintenance_industrial_operations.md
@@ -1,15 +1,14 @@
 ---
+redirect_from:
+- '/industry 4.0/predictive maintenance/data analytics/introduction_predictive_maintenance_industrial_operations/'
 title: "Introduction to Predictive Maintenance: Transforming Industrial Operations Through Intelligent Asset Management"
 categories:
-- Industry 4.0
 - Predictive Maintenance
-- Data Analytics
 tags:
-- predictive maintenance
-- condition monitoring
-- industrial IoT
-- asset management
-- machine learning
+- Predictive Maintenance
+- Model Monitoring
+- Industrial IoT
+- Machine Learning
 author_profile: false
 seo_title: Introduction to Predictive Maintenance
 seo_description: The future of maintenance strategy, and how AI, IoT, and data analytics are transforming industrial asset management.

--- a/_posts/2025-04-27-techniques_moniitoring_managing_model_drift_production.md
+++ b/_posts/2025-04-27-techniques_moniitoring_managing_model_drift_production.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Model Monitoring
 classes: wide
 date: '2025-04-27'
 excerpt: Model drift is inevitable in production ML systems. This guide explores monitoring
@@ -22,6 +21,8 @@ keywords:
 - Seldon
 - Tfx
 - Retraining models
+redirect_from:
+- '/machine learning/model monitoring/techniques_moniitoring_managing_model_drift_production/'
 seo_description: Best practices and tools for monitoring model performance, detecting drift, and retraining models with MLflow, Seldon, and TFX.
 seo_title: Monitoring and Managing Model Drift in Production ML Systems
 seo_type: article
@@ -29,12 +30,9 @@ summary: This article outlines practical techniques for managing model drift in 
   learning production environments, including real-time monitoring, automated alerts,
   and retraining using popular tools like MLflow, Seldon, and TFX.
 tags:
-- Model drift
-- Model monitoring
-- Ml ops
-- Mlflow
-- Tfx
-- Seldon
+- Data Drift
+- Model Monitoring
+- MLOps
 title: Techniques for Monitoring and Managing Model Drift in Production
 ---
 

--- a/_posts/2025-04-30-llm_agents_finance_intelligent_automation_analysis.md
+++ b/_posts/2025-04-30-llm_agents_finance_intelligent_automation_analysis.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Finance
-- Artificial Intelligence
-- Large Language Models
+- Economics
 classes: wide
 date: '2025-04-30'
 excerpt: Large Language Model (LLM) agents are revolutionizing the finance industry
@@ -22,6 +20,8 @@ keywords:
 - Financial automation
 - Natural language processing
 - Financial data analysis
+redirect_from:
+- '/finance/artificial intelligence/large language models/llm_agents_finance_intelligent_automation_analysis/'
 seo_description: How Large Language Model agents are reshaping finance by automating analysis, reporting, and decision-making.
 seo_title: 'LLM Agents in Finance: Transforming Workflows'
 seo_type: article
@@ -29,11 +29,10 @@ summary: This article examines the rise of LLM-powered agents in finance, discus
   how autonomous AI systems built on large language models are transforming risk assessment,
   portfolio management, regulatory compliance, and market analysis.
 tags:
-- Llm agents
-- Finance automation
-- Financial analysis
-- Ai assistants
-- Autonomous agents
+- Natural Language Processing
+- MLOps
+- Finance
+- Artificial Intelligence
 title: 'LLM Agents in Finance: Unlocking Intelligent Automation and Analysis'
 ---
 

--- a/_posts/2025-05-01-agentbased_models_abm_macroeconomics_mathematical_perspective.md
+++ b/_posts/2025-05-01-agentbased_models_abm_macroeconomics_mathematical_perspective.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Macroeconomics
-- Computational Economics
-- Agent-Based Modeling
+- Economics
 classes: wide
 date: '2025-05-01'
 excerpt: Agent-Based Models (ABM) offer a powerful framework for simulating macroeconomic
@@ -23,6 +21,8 @@ keywords:
 - Heterogeneous agents
 - Economic networks
 - Python
+redirect_from:
+- '/macroeconomics/computational economics/agent-based modeling/agentbased_models_abm_macroeconomics_mathematical_perspective/'
 seo_description: How agent-based modeling (ABM) simulates macroeconomics bottom-up with heterogeneous agents and dynamic interactions.
 seo_title: Understanding Agent-Based Models (ABM) in Macroeconomics
 seo_type: article
@@ -30,11 +30,9 @@ summary: This article introduces agent-based models in macroeconomics, explainin
   how they are built, the math behind their dynamics, and their value in simulating
   emergent economic phenomena like unemployment, inflation, and market shocks.
 tags:
-- Abm
-- Macroeconomic modeling
-- Computational simulation
-- Heterogeneous agents
-- Economic systems
+- Economics
+- Monte Carlo
+- Artificial Intelligence
 - Python
 title: 'Agent-Based Models (ABM) in Macroeconomics: A Mathematical Perspective'
 ---

--- a/_posts/2025-05-25-Understanding_Statistical_Models.md
+++ b/_posts/2025-05-25-Understanding_Statistical_Models.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Science
 classes: wide
 date: '2025-05-25'
 excerpt: Statistical models lie at the heart of modern data science and quantitative
@@ -22,6 +21,8 @@ keywords:
 - Prediction
 - Inference
 - Simulation
+redirect_from:
+- '/statistics/data science/Understanding_Statistical_Models/'
 seo_description: What statistical models are, how they work, and why they are fundamental to analysis, prediction, and decision-making.
 seo_title: What Is a Statistical Model?
 seo_type: article
@@ -29,10 +30,9 @@ summary: This article explores the essence of statistical models, including thei
   structure, function, and real-world applications, with a focus on their role in
   inference, uncertainty quantification, and decision support.
 tags:
-- Statistical models
-- Inference
-- Simulation
-- Predictive analytics
+- Statistical Modeling
+- Monte Carlo
+- Machine Learning
 - Probability
 title: 'Understanding Statistical Models: Foundations, Functions, and Applications'
 ---

--- a/_posts/2025-05-26-detect_data_drift_machine_learning_models.md
+++ b/_posts/2025-05-26-detect_data_drift_machine_learning_models.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Model Monitoring
 classes: wide
 date: '2025-05-26'
 excerpt: Data drift is one of the primary threats to model reliability in production.
@@ -22,6 +21,8 @@ keywords:
 - Chi-square test
 - Evidently ai
 - Nannyml
+redirect_from:
+- '/machine learning/model monitoring/detect_data_drift_machine_learning_models/'
 seo_description: How to detect data drift with KL Divergence and PSI, and tools like NannyML and Evidently AI for maintaining accuracy in production.
 seo_title: 'Detecting Data Drift in Machine Learning: Methods and Tools'
 seo_type: article
@@ -29,11 +30,10 @@ summary: Explore how to detect data drift in machine learning systems, including
   techniques like KL Divergence, PSI, and Chi-square tests, as well as practical tools
   like NannyML and Evidently AI.
 tags:
-- Data drift
-- Drift detection
-- Model monitoring
-- Statistical tests
-- Ml ops
+- Data Drift
+- Model Monitoring
+- Hypothesis Testing
+- MLOps
 title: How to Detect Data Drift in Machine Learning Models
 ---
 

--- a/_posts/2025-05-27-using_natural_language_processing_economic_policy_analysis.md
+++ b/_posts/2025-05-27-using_natural_language_processing_economic_policy_analysis.md
@@ -1,9 +1,7 @@
 ---
 author_profile: false
 categories:
-- Natural Language Processing
-- Economics
-- Policy Analysis
+- Machine Learning
 classes: wide
 date: '2025-05-27'
 excerpt: Natural Language Processing offers powerful tools for interpreting economic
@@ -23,6 +21,8 @@ keywords:
 - Machine learning for policy
 - Government document analysis
 - Python
+redirect_from:
+- '/natural language processing/economics/policy analysis/using_natural_language_processing_economic_policy_analysis/'
 seo_description: How NLP techniques analyze political texts and government documents to assess and predict economic policy impacts.
 seo_title: NLP for Economic Policy Analysis
 seo_type: article
@@ -30,11 +30,9 @@ summary: This article examines how NLP techniques are applied to analyze politic
   speeches, government reports, and legislative texts to better understand and forecast
   economic policy trends and impacts.
 tags:
-- Nlp
-- Economic policy
-- Text mining
-- Political analysis
-- Machine learning
+- Natural Language Processing
+- Economics
+- Machine Learning
 - Python
 title: Using Natural Language Processing for Economic Policy Analysis
 ---

--- a/_posts/2025-06-05-Least_Angle_Regression.md
+++ b/_posts/2025-06-05-Least_Angle_Regression.md
@@ -30,9 +30,7 @@ summary: This article explores Least Angle Regression (LARS), explaining its cor
   most effectively applied.
 tags:
 - Regression
-- Lars
-- Linear models
-- Feature selection
+- Feature Engineering
 - Python
 title: 'Least Angle Regression: A Gentle Dive into LARS'
 ---

--- a/_posts/2025-06-06-exploratory_data_analysis_intro.md
+++ b/_posts/2025-06-06-exploratory_data_analysis_intro.md
@@ -27,10 +27,10 @@ summary: This guide covers the core principles of Exploratory Data Analysis, dem
   how to inspect, clean, and visualize datasets to uncover patterns and inform subsequent
   modeling steps.
 tags:
-- Eda
-- Data science
+- Exploratory Data Analysis
+- Data Science
 - Python
-- Visualization
+- Data Visualization
 title: 'Exploratory Data Analysis: A Beginner''s Guide'
 ---
 

--- a/_posts/2025-06-07-why_math_statistics_foundations_data_science.md
+++ b/_posts/2025-06-07-why_math_statistics_foundations_data_science.md
@@ -26,11 +26,10 @@ summary: To excel in data science, you need more than coding skills. This articl
   explains how mathematics and statistics underpin popular algorithms and why understanding
   them prevents costly mistakes.
 tags:
-- Mathematics
+- Mathematical Modeling
 - Statistics
-- Machine learning
-- Data science
-- Algorithms
+- Machine Learning
+- Data Science
 title: Why Data Scientists Need Math and Statistics
 ---
 

--- a/_posts/2025-06-09-feature_engineering_time_series.md
+++ b/_posts/2025-06-09-feature_engineering_time_series.md
@@ -26,9 +26,9 @@ seo_type: article
 summary: This post explains how to engineer features such as lagged values, rolling
   statistics, and seasonal indicators to improve model performance on sequential data.
 tags:
-- Feature engineering
-- Time series
-- Machine learning
+- Feature Engineering
+- Time Series
+- Machine Learning
 - Forecasting
 - Python
 title: Crafting Time Series Features for Better Models

--- a/_posts/2025-06-10-arima_forecasting_python.md
+++ b/_posts/2025-06-10-arima_forecasting_python.md
@@ -25,10 +25,9 @@ seo_type: article
 summary: This tutorial walks through the basics of ARIMA modeling, from identifying
   parameters to validating forecasts on real data.
 tags:
-- Arima
+- Time Series
 - Forecasting
 - Python
-- Time series
 title: 'ARIMA Modeling in Python: A Quick Start Guide'
 ---
 

--- a/_posts/2025-06-11-introduction_neural_networks.md
+++ b/_posts/2025-06-11-introduction_neural_networks.md
@@ -25,9 +25,8 @@ seo_type: article
 summary: This overview demystifies neural networks by highlighting how layered structures
   learn complex patterns from data.
 tags:
-- Neural networks
-- Deep learning
-- Machine learning
+- Neural Networks
+- Machine Learning
 title: A Gentle Introduction to Neural Networks
 ---
 

--- a/_posts/2025-06-12-hyperparameter_tuning_strategies.md
+++ b/_posts/2025-06-12-hyperparameter_tuning_strategies.md
@@ -25,10 +25,9 @@ seo_type: article
 summary: This guide covers systematic approaches for searching the hyperparameter
   space, along with libraries that automate the process.
 tags:
-- Hyperparameters
-- Model selection
+- Statistical Modeling
 - Optimization
-- Machine learning
+- Machine Learning
 title: Hyperparameter Tuning Strategies
 ---
 

--- a/_posts/2025-06-13-model_deployment_best_practices.md
+++ b/_posts/2025-06-13-model_deployment_best_practices.md
@@ -25,10 +25,8 @@ seo_type: article
 summary: This post outlines reliable approaches for serving machine learning models
   in production environments and keeping them up to date.
 tags:
-- Deployment
-- Mlops
-- Production
-- Data science
+- MLOps
+- Data Science
 title: 'Model Deployment: Best Practices and Tips'
 ---
 

--- a/_posts/2025-06-14-data_ethics_machine_learning.md
+++ b/_posts/2025-06-14-data_ethics_machine_learning.md
@@ -26,9 +26,7 @@ summary: This article discusses how to address fairness, accountability, and tra
   when building machine learning solutions.
 tags:
 - Ethics
-- Responsible ai
-- Bias
-- Machine learning
+- Machine Learning
 title: Why Data Ethics Matters in Machine Learning
 ---
 

--- a/_posts/2025-06-15-smote_pitfalls.md
+++ b/_posts/2025-06-15-smote_pitfalls.md
@@ -26,9 +26,7 @@ summary: Synthetic Minority Over-sampling Technique (SMOTE) creates artificial e
   to balance classes, but ignoring its assumptions can distort your dataset and harm
   model performance.
 tags:
-- Smote
-- Class imbalance
-- Machine learning
+- Machine Learning
 title: Why SMOTE Isn't Always the Answer
 ---
 

--- a/_posts/2025-07-01-reinforcement_learning_optimizing_maintenance.md
+++ b/_posts/2025-07-01-reinforcement_learning_optimizing_maintenance.md
@@ -1,18 +1,14 @@
 ---
+redirect_from:
+- '/industrial ai/predictive maintenance/machine learning/reinforcement_learning_optimizing_maintenance/'
 title: >-
   The Role of Reinforcement Learning in Optimizing Maintenance Strategies:
   Dynamic Predictive Maintenance Through Reward-Based Learning
 categories:
-  - Industrial AI
-  - Predictive Maintenance
-  - Machine Learning
+- Predictive Maintenance
 tags:
-  - Reinforcement Learning
-  - Maintenance Optimization
-  - Equipment Reliability
-  - Industrial AI
-  - Deep Q-Networks
-  - Actor-Critic
+- Supervised Learning
+- Optimization
 author_profile: false
 seo_title: Reinforcement Learning for Predictive Maintenance
 seo_description: How reinforcement learning enables adaptive maintenance strategies, cutting costs and improving uptime through reward-based decisions.

--- a/_posts/2025-07-21-survival_analysis_public_policy.md
+++ b/_posts/2025-07-21-survival_analysis_public_policy.md
@@ -1,15 +1,11 @@
 ---
+redirect_from:
+- '/public policy/data science/government analytics/survival_analysis_public_policy/'
 title: "Survival Analysis in Public Policy and Government: Applications, Methodology, and Implementation"
 categories:
-- Public Policy
 - Data Science
-- Government Analytics
 tags:
-- survival analysis
-- public policy
-- time-to-event modeling
-- government data
-- evidence-based policymaking
+- Survival Analysis
 author_profile: false
 seo_title: Survival Analysis for Public Policy in Python
 seo_description: How survival analysis models time-to-event data for public policy across health, housing, and education, with Python examples.

--- a/_posts/2025-07-23-multivariate_time_series_forecasting_var_and_vecm_models_explained.md
+++ b/_posts/2025-07-23-multivariate_time_series_forecasting_var_and_vecm_models_explained.md
@@ -1,16 +1,12 @@
 ---
+redirect_from:
+- '/time series/econometrics/forecasting/multivariate_time_series_forecasting_var_and_vecm_models_explained/'
 title: 'Multivariate Time Series Forecasting: VAR and VECM Models Explained'
 categories:
-  - Time Series
-  - Econometrics
-  - Forecasting
+- Time Series
 tags:
-  - VAR
-  - VECM
-  - cointegration
-  - Johansen test
-  - Python
-  - stationarity
+- Python
+- Time Series
 author_profile: false
 seo_title: 'Multivariate Forecasting: VAR vs VECM in Python'
 seo_description: >-

--- a/_posts/2025-07-26-advanced_predictive_maintenance_machine_learning_implementation.md
+++ b/_posts/2025-07-26-advanced_predictive_maintenance_machine_learning_implementation.md
@@ -1,15 +1,14 @@
 ---
+redirect_from:
+- '/industry 4.0/predictive maintenance/data analytics/advanced_predictive_maintenance_machine_learning_implementation/'
 title: "Advanced Predictive Maintenance: Machine Learning Implementation for Industrial Operations"
 categories:
-- Industry 4.0
 - Predictive Maintenance
-- Data Analytics
 tags:
-- predictive maintenance
-- condition monitoring
-- industrial IoT
-- asset management
-- machine learning
+- Predictive Maintenance
+- Model Monitoring
+- Industrial IoT
+- Machine Learning
 author_profile: false
 seo_title: Advanced Predictive Maintenance with Machine Learning
 seo_description: How predictive maintenance is reshaping industrial asset management through AI, IoT, and data analytics.

--- a/_posts/2025-08-01-survival_analysis_applied_finance.md
+++ b/_posts/2025-08-01-survival_analysis_applied_finance.md
@@ -1,15 +1,13 @@
 ---
+redirect_from:
+- '/finance/data science/risk modeling/survival_analysis_applied_finance/'
 title: "Survival Analysis Applied to Finance: A Comprehensive Guide"
 categories:
-- finance
-- data science
-- risk modeling
+- Economics
 tags:
-- survival analysis
-- credit risk
-- prepayment modeling
-- investment analysis
-- customer retention
+- Survival Analysis
+- Finance
+- Customer Analytics
 author_profile: false
 seo_title: 'Survival Analysis in Finance: Techniques and Cases'
 seo_description: 'A complete guide to survival analysis in finance: time-to-event modeling for credit risk, investment analysis, and churn.'

--- a/_posts/2025-08-02-real_time_traffic_anomaly_detection_systems.md
+++ b/_posts/2025-08-02-real_time_traffic_anomaly_detection_systems.md
@@ -1,17 +1,14 @@
 ---
+redirect_from:
+- '/transportation/artificial intelligence/data science/real_time_traffic_anomaly_detection_systems/'
 title: "Real-Time Traffic Anomaly Detection Systems: Advanced Incident Detection and Response"
 categories:
-- Transportation
-- Artificial Intelligence
-- Data Science
+- Environment
 
 tags:
-- Traffic Anomaly Detection
-- Incident Detection
-- Smart Transportation
-- Real-Time Analytics
+- Anomaly Detection
+- Transportation
 - Machine Learning
-- Statistical Process Control
 
 author_profile: false
 seo_title: Traffic Anomaly Detection for Smart Transport

--- a/_posts/2025-08-02-survival_analysis_supply_chain_logistics.md
+++ b/_posts/2025-08-02-survival_analysis_supply_chain_logistics.md
@@ -1,15 +1,12 @@
 ---
+redirect_from:
+- '/supply-chain/analytics/data-science/survival_analysis_supply_chain_logistics/'
 title: 'Survival Analysis in Supply Chain and Logistics: A Comprehensive Guide'
 categories:
-  - supply-chain
-  - analytics
-  - data-science
+- Economics
 tags:
-  - survival analysis
-  - supply chain analytics
-  - logistics modeling
-  - inventory management
-  - shipment prediction
+- Survival Analysis
+- Supply Chain
 author_profile: false
 seo_title: Survival Analysis for Supply Chain and Logistics
 seo_description: How survival analysis models delivery times, predicts stockouts, manages perishables, and assesses supplier risk.

--- a/_posts/2025-08-03-evaluating_time_series_forecasting_models_metrics_best_bractices.md
+++ b/_posts/2025-08-03-evaluating_time_series_forecasting_models_metrics_best_bractices.md
@@ -1,16 +1,12 @@
 ---
+redirect_from:
+- '/time series/model evaluation/forecasting/evaluating_time_series_forecasting_models_metrics_best_bractices/'
 title: 'Evaluating Time Series Forecasting Models: Metrics and Best Practices'
 categories:
-  - Time Series
-  - Model Evaluation
-  - Forecasting
+- Time Series
 tags:
-  - RMSE
-  - MAE
-  - MAPE
-  - model validation
-  - rolling-origin evaluation
-  - forecasting metrics
+- Model Evaluation
+- Model Monitoring
 author_profile: false
 seo_title: Evaluating Time Series Forecasting Models
 seo_description: How to evaluate time series forecasts with RMSE, MAE, AIC, and BIC, plus validation strategies and coding examples.

--- a/_posts/2025-08-03-optimizing_data_pipelines_apache_airflow.md
+++ b/_posts/2025-08-03-optimizing_data_pipelines_apache_airflow.md
@@ -1,18 +1,15 @@
 ---
+redirect_from:
+- '/data engineering/workflow orchestration/devops/optimizing_data_pipelines_apache_airflow/'
 title: >-
   Optimizing Data Pipelines with Apache Airflow: Building Scalable,
   Fault-Tolerant Data Infrastructure
 categories:
-  - Data Engineering
-  - Workflow Orchestration
-  - DevOps
+- Programming
 tags:
-  - Apache Airflow
-  - Data Pipelines
-  - Workflow Automation
-  - DAG Optimization
-  - Kubernetes
-  - Celery Executor
+- Data Engineering
+- MLOps
+- Optimization
 author_profile: false
 seo_title: Optimizing Apache Airflow for Data Pipelines
 seo_description: 'Designing scalable, fault-tolerant data pipelines with Apache Airflow: executor benchmarking, DAG patterns, and observability.'

--- a/_posts/2025-08-07-smarter_tree_splits.md
+++ b/_posts/2025-08-07-smarter_tree_splits.md
@@ -1,17 +1,13 @@
 ---
+redirect_from:
+- '/machine-learning/tree-algorithms/smarter_tree_splits/'
 title: "Smarter Tree Splits: Understanding Friedman MSE in Regression Trees"
 categories:
-- machine-learning
-- tree-algorithms
+- Machine Learning
 
 tags:
-- decision-trees
-- regression
-- MSE
-- gradient-boosting
-- scikit-learn
-- xgboost
-- lightgbm
+- Decision Trees
+- Regression
 
 author_profile: false
 seo_title: "Friedman MSE vs Classic MSE in Regression Trees"

--- a/_posts/2025-08-13-preregistering_structural_equation_modeling.md
+++ b/_posts/2025-08-13-preregistering_structural_equation_modeling.md
@@ -1,14 +1,13 @@
 ---
+redirect_from:
+- '/research methods/preregistering_structural_equation_modeling/'
 title: >-
   Preregistering Structural Equation Modeling (SEM) Studies: A Comprehensive
   Guide
 categories:
-  - Research Methods
+- Statistics
 tags:
-  - SEM
-  - Preregistration
-  - Open Science
-  - Reproducibility
+- Research Methodology
 author_profile: false
 seo_title: Preregistering SEM Studies
 seo_description: 'How to preregister SEM studies: software environments, modeling decisions, fit criteria, and contingency plans for reproducibility.'

--- a/_posts/2025-08-29-role_natural_language_processing_predictive_maintenance.md
+++ b/_posts/2025-08-29-role_natural_language_processing_predictive_maintenance.md
@@ -1,19 +1,15 @@
 ---
+redirect_from:
+- '/data science/industrial ai/natural language processing/predictive maintenance/role_natural_language_processing_predictive_maintenance/'
 title: >-
   The Role of Natural Language Processing in Predictive Maintenance: Leveraging
   Unstructured Data for Enhanced Industrial Intelligence
 categories:
-  - Data Science
-  - Industrial AI
-  - Natural Language Processing
-  - Predictive Maintenance
+- Data Science
 tags:
-  - Predictive Maintenance
-  - NLP
-  - Industrial Analytics
-  - Maintenance Logs
-  - Text Mining
-  - Machine Learning
+- Predictive Maintenance
+- Natural Language Processing
+- Machine Learning
 author_profile: false
 seo_title: NLP for Predictive Maintenance
 seo_description: How NLP enhances predictive maintenance by extracting insights from maintenance logs, work orders, and technical documentation.

--- a/_posts/2025-08-31-impact_predictive_maintenance_operatrional_efficiency.md
+++ b/_posts/2025-08-31-impact_predictive_maintenance_operatrional_efficiency.md
@@ -1,17 +1,16 @@
 ---
+redirect_from:
+- '/data science/industrial analytics/predictive maintenance/impact_predictive_maintenance_operatrional_efficiency/'
 title: >-
   The Impact of Predictive Maintenance on Operational Efficiency: A Data Science
   Perspective
 categories:
-  - Data Science
-  - Industrial Analytics
-  - Predictive Maintenance
+- Data Science
 tags:
-  - Predictive Maintenance
-  - Machine Learning
-  - Industrial IoT
-  - Operational Efficiency
-  - Condition Monitoring
+- Predictive Maintenance
+- Machine Learning
+- Industrial IoT
+- Model Monitoring
 author_profile: false
 seo_title: Predictive Maintenance and Operational Efficiency
 seo_description: 'The impact of predictive maintenance on industrial operations: data science methods, ML architectures, and measured outcomes.'

--- a/_posts/2025-09-01-traffic_prediction_advanced_analytics_smart_transportation_systems.md
+++ b/_posts/2025-09-01-traffic_prediction_advanced_analytics_smart_transportation_systems.md
@@ -1,16 +1,14 @@
 ---
+redirect_from:
+- '/transportation/data science/machine learning/traffic_prediction_advanced_analytics_smart_transportation_systems/'
 title: 'Traffic Prediction: Advanced Analytics for Smart Transportation Systems'
 categories:
-  - Transportation
-  - Data Science
-  - Machine Learning
+- Environment
 tags:
-  - Traffic Prediction
-  - Smart Cities
-  - Intelligent Transportation Systems
-  - Time Series Forecasting
-  - Deep Learning
-  - Feature Engineering
+- Transportation
+- Time Series
+- Neural Networks
+- Feature Engineering
 author_profile: false
 seo_title: Advanced Traffic Prediction with Smart Analytics and AI
 seo_description: 'Traffic prediction with AI and advanced analytics: data sources, preprocessing, modeling, and evaluation techniques.'

--- a/_posts/2025-09-02-the_hidden_crisis_what happens_when_stop_funding_research.md
+++ b/_posts/2025-09-02-the_hidden_crisis_what happens_when_stop_funding_research.md
@@ -1,15 +1,11 @@
 ---
+redirect_from:
+- '/science policy/research funding/innovation/the_hidden_crisis_what-happens_when_stop_funding_research/'
 title: "The Hidden Crisis: What Happens When We Stop Funding Fundamental Research"
 categories:
-- Science Policy
-- Research Funding
-- Innovation
+- Research
 tags:
-- Fundamental Research
-- Basic Science
-- Science Policy
-- Technology
-- Education
+- Research Methodology
 author_profile: false
 seo_title: Why Defunding Basic Science Threatens Our Future
 seo_description: Why defunding fundamental research threatens innovation, national security, and scientific progress over the long term.

--- a/_posts/2025-09-03-probability_calibration_machine_learning.md
+++ b/_posts/2025-09-03-probability_calibration_machine_learning.md
@@ -1,16 +1,14 @@
 ---
+redirect_from:
+- '/machine-learning/uncertainty-quantification/model-evaluation/probability_calibration_machine_learning/'
 title: "Probability Calibration in Machine Learning: From Classical Methods to Modern Approaches and Venn–ABERS Predictors"
 categories:
-- machine-learning
-- uncertainty-quantification
-- model-evaluation
+- Machine Learning
 
 tags:
-- probability-calibration
-- conformal-prediction
-- venn-abers
-- model-evaluation
-- uncertainty-estimation
+- Probability
+- Model Evaluation
+- Confidence Intervals
 
 author_profile: false
 seo_title: 'Probability Calibration: Classical to Venn-ABERS'

--- a/_posts/2025-09-12-utilitarian_thinking_destroying_foundation_human_progress.md
+++ b/_posts/2025-09-12-utilitarian_thinking_destroying_foundation_human_progress.md
@@ -1,15 +1,11 @@
 ---
+redirect_from:
+- '/philosophy of science/higher education/research policy/utilitarian_thinking_destroying_foundation_human_progress/'
 title: "The Intellectual Crisis: How Utilitarian Thinking is Destroying the Foundation of Human Progress"
 categories:
-- Philosophy of Science
-- Higher Education
-- Research Policy
+- Research
 tags:
-- Pure Research
-- Utilitarianism
-- Academic Freedom
-- Intellectual Culture
-- Innovation Policy
+- Research Methodology
 author_profile: false
 seo_title: Why Pure Inquiry Matters More Than Ever
 seo_description: How utilitarian pressures are turning academia toward short-term gains, and why pure research must be protected.

--- a/_posts/2025-09-14-the_dangerous_push_towards_pratical_mathematics.md
+++ b/_posts/2025-09-14-the_dangerous_push_towards_pratical_mathematics.md
@@ -1,15 +1,11 @@
 ---
+redirect_from:
+- '/mathematics/science policy/research funding/the_dangerous_push_towards_pratical_mathematics/'
 title: "The Dangerous Push Toward Practical Mathematics: Why Pure Research Must Remain Protected"
 categories:
 - Mathematics
-- Science Policy
-- Research Funding
 tags:
-- Pure Mathematics
-- Applied Mathematics
-- Scientific Innovation
-- Academic Policy
-- Mathematical History
+- Mathematical Modeling
 author_profile: false
 seo_title: Why Pure Mathematics Must Be Protected
 seo_description: A defense of pure mathematics against pressure for immediate application, and its role in long-term innovation.

--- a/_posts/2025-10-16-temporal_validation_machine_learning.md
+++ b/_posts/2025-10-16-temporal_validation_machine_learning.md
@@ -1,0 +1,363 @@
+---
+title: "Temporal Validation in Machine Learning: Testing Models Against the Future"
+categories:
+- Machine Learning
+tags:
+- Model Evaluation
+- Time Series
+- MLOps
+author_profile: false
+seo_title: "Temporal Validation in Machine Learning"
+seo_description: 'Temporal validation in machine learning: time-based splits, backtesting, leakage, feature cutoffs, and delayed labels.'
+excerpt: "Temporal validation evaluates machine learning models the way they will be used: trained on the past and tested on the future."
+summary: "This article explains temporal validation for machine learning systems. It covers why random splits fail for time-dependent data, how to design time-based train and test windows, how leakage enters through features and labels, how rolling backtests work, and how temporal validation connects to drift monitoring and production reliability."
+keywords:
+- "temporal validation"
+- "time based train test split"
+- "machine learning backtesting"
+- "future leakage"
+- "model evaluation"
+- "training serving skew"
+classes: wide
+date: '2025-10-16'
+header:
+  image: /assets/images/data_science_10.jpg
+  og_image: /assets/images/data_science_10.jpg
+  overlay_image: /assets/images/data_science_10.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_10.jpg
+  twitter_image: /assets/images/data_science_10.jpg
+---
+
+Machine learning evaluation often begins with a random train-test split. The dataset is shuffled, part of it is used for training, and the rest is held out for testing. For many static problems this is a reasonable starting point. For systems that make decisions over time, it can be badly misleading.
+
+Production models do not predict randomly sampled records from the same historical period. They predict future cases using information available at the time of prediction. A fraud model trained in January scores transactions in February. A churn model trained on last quarter predicts customers this quarter. A demand model trained on past sales forecasts future demand. A maintenance model trained on earlier sensor behavior estimates future failure risk.
+
+Temporal validation evaluates the model in that same direction:
+
+$$
+\text{train on the past} \rightarrow \text{test on the future}
+$$
+
+This sounds simple, but it changes almost every part of evaluation. The split must respect time. Features must be computed with historical cutoffs. Labels may arrive late. Data distributions may drift. Entities may appear in both training and testing periods. Model retraining schedules must be reflected. Metrics should be computed not only once, but across several future windows.
+
+Temporal validation is not only a time-series technique. It is a reliability requirement for any machine learning system where the future differs from the past.
+
+## Why Random Splits Fail
+
+Random splits assume that rows are exchangeable. In plain language, they assume that the order of the rows does not matter. If each observation could have appeared in any order without changing the learning problem, random splitting is often defensible.
+
+Many machine learning datasets violate this assumption.
+
+Customer behavior changes after campaigns, price changes, economic shocks, competitor actions, product launches, policy changes, seasonality, and user learning. Fraud patterns adapt after detection rules change. Medical workflows change after new guidelines. Industrial sensors drift as machines age. Support tickets change after a software release. Lending data changes after underwriting policy changes.
+
+A random split mixes all of these periods together. The model may train on patterns from the future and test on records from the past. It may learn categories, seasonality, failure modes, or target relationships that would not have been known at the time of prediction.
+
+The result is optimistic validation performance.
+
+The model looks better in the notebook than it will in production because the evaluation allowed information to travel backward in time.
+
+## The Basic Time-Based Split
+
+The simplest temporal validation split uses an explicit cutoff date.
+
+Training data:
+
+$$
+t \leq T
+$$
+
+Test data:
+
+$$
+t > T
+$$
+
+For example, train on records from January through September and test on records from October. This is often much better than a random split because it preserves the causal direction of prediction.
+
+But the cutoff must be chosen carefully. The relevant time is not always the row timestamp. It may be the event time, application time, transaction time, prediction time, label availability time, or feature snapshot time.
+
+For a churn model, the prediction time may be the date when the retention action would be taken. For a fraud model, it may be the transaction authorization time. For a healthcare model, it may be admission time, not discharge time. For a predictive maintenance model, it may be the timestamp at which an alert would be issued.
+
+Temporal validation begins by defining when the model knows what it knows.
+
+## Feature Cutoffs
+
+The most common temporal validation error is feature leakage.
+
+A feature leaks when it uses information that would not be available at prediction time. This can happen even when the train-test split itself is time-based.
+
+Examples include:
+
+- Aggregating customer purchases using data after the prediction date
+- Computing category target encodings using future labels
+- Using a status field updated after the outcome occurs
+- Including a support-ticket resolution code in a model that predicts escalation
+- Computing rolling averages without respecting the cutoff
+- Using a "days since last event" feature that accidentally looks into the future
+- Joining a slowly changing dimension table without point-in-time correctness
+
+The fix is point-in-time feature construction. Every feature for row \( i \) should be computed using only data available at prediction time \( t_i \).
+
+This is stricter than saying the feature was available somewhere in the historical database. Many production databases store the current state of an entity, not the historical state that was visible at the time.
+
+If the model would not have known it then, validation should not know it now.
+
+## Delayed Labels
+
+Labels often arrive after the prediction.
+
+A loan default label may take months to mature. A churn label may require waiting until a subscription does not renew. A fraud label may appear after investigation. A hospital readmission label requires observing the patient after discharge. A maintenance failure label may depend on later inspection or repair logs.
+
+Delayed labels complicate validation because the model is trained at one time, predicts at another time, and receives truth later.
+
+Suppose a model is trained on January 1. If default labels require 90 days to mature, then the training data cannot include loans issued in late December with known outcomes unless those outcomes were not truly available on January 1.
+
+The evaluation design must account for label maturity:
+
+$$
+\text{label time} = \text{event time} + \text{observation delay}
+$$
+
+Ignoring this delay creates future leakage. It also leads teams to overestimate how much fresh labeled data is available for retraining.
+
+## Rolling Backtests
+
+A single time split is useful, but it may be fragile. Performance can depend heavily on the chosen cutoff.
+
+Rolling backtesting evaluates a model over several historical prediction periods. Each fold trains on data before a cutoff and tests on a later window.
+
+Example:
+
+| Fold | Train Window | Test Window |
+|---|---|---|
+| 1 | Jan-Mar | Apr |
+| 2 | Jan-Apr | May |
+| 3 | Jan-May | Jun |
+| 4 | Jan-Jun | Jul |
+
+This expanding-window design mimics a model retrained over time with growing data.
+
+Another option is a sliding window:
+
+| Fold | Train Window | Test Window |
+|---|---|---|
+| 1 | Jan-Mar | Apr |
+| 2 | Feb-Apr | May |
+| 3 | Mar-May | Jun |
+| 4 | Apr-Jun | Jul |
+
+Sliding windows are useful when older data becomes less relevant because of drift, policy changes, or changing behavior.
+
+Rolling backtests provide a distribution of performance across time. That distribution is often more informative than one test score.
+
+## Choosing the Prediction Horizon
+
+Temporal validation should match the prediction horizon.
+
+A demand model may forecast one day ahead, one week ahead, or one month ahead. A churn model may predict churn in the next 30 days. A maintenance model may predict failure in the next 7 days. A credit model may predict default within 12 months.
+
+The horizon changes the label definition, feature cutoff, and operational value.
+
+For a horizon \( h \), the model uses information up to time \( t \) and predicts an outcome over:
+
+$$
+(t, t+h]
+$$
+
+If the horizon is too short, the model may not give the organization enough time to act. If it is too long, the signal may be weak and the decision may be vague.
+
+Validation should evaluate the horizon that the business will actually use.
+
+## Entity Leakage
+
+Temporal splits do not automatically prevent entity leakage.
+
+If the same customer, patient, machine, merchant, store, or user appears in both training and testing, the model may learn entity-specific patterns that do not generalize to new entities. Sometimes this is acceptable. Sometimes it is not.
+
+The right split depends on deployment.
+
+If the model will score future behavior for existing customers, allowing the same customers across time may be realistic. If the model must generalize to new customers, a grouped temporal split may be needed.
+
+For example:
+
+- Train on earlier customers and earlier periods.
+- Test on future periods for customers not seen during training.
+- Evaluate separately on returning entities and new entities.
+
+This distinction matters for embeddings, target encodings, behavioral aggregates, and historical counters. A model that works for known entities may fail for cold-start cases.
+
+Temporal validation should make that boundary visible.
+
+## Preprocessing Must Be Time-Aware
+
+Temporal leakage can enter through preprocessing, not only through features.
+
+Scaling parameters, imputers, encoders, dimensionality reduction, feature selection, and calibration models should be fit only on the training period inside each validation fold.
+
+Common mistakes include:
+
+- Fitting a scaler on the full dataset before splitting
+- Computing imputation values using future records
+- Learning vocabulary from future text
+- Selecting features based on full-period target association
+- Calibrating probabilities using labels from the test period
+- Tuning thresholds on future outcomes
+
+The validation pipeline should mirror production:
+
+1. Fit preprocessing on past data.
+2. Transform future data with the fitted preprocessing.
+3. Score future data.
+4. Evaluate after labels mature.
+
+Any shortcut that uses future data during preprocessing weakens the evaluation.
+
+## Model Selection Over Time
+
+Temporal validation should be used for model selection, not only final reporting.
+
+If hyperparameters are chosen using a random split, then final temporal testing may reveal that the selected model was optimized for the wrong evaluation regime. Models that perform well under random validation may rely on unstable shortcuts.
+
+A better strategy is nested or repeated temporal validation. Hyperparameters are selected using earlier temporal folds, then the final model is evaluated on a later holdout period.
+
+This is more expensive, but it protects against choosing a model that wins only because time was ignored.
+
+The same principle applies to feature selection, threshold selection, calibration, and retraining cadence. If the decision will happen in time, the selection process should respect time.
+
+## Measuring Degradation
+
+Temporal validation reveals how performance changes as the test window moves farther from the training period.
+
+For each test period, track:
+
+- Predictive performance
+- Calibration
+- Error by slice
+- Data drift
+- Label distribution
+- Feature missingness
+- Prediction distribution
+- Business outcomes
+
+Performance decay can indicate drift. But not all degradation has the same cause.
+
+The population may have changed. The target relationship may have changed. Upstream data may have changed. The label process may have changed. A new policy may have altered who enters the dataset. A competitor action may have shifted user behavior.
+
+Temporal validation does not diagnose every cause by itself, but it shows when a model trained on historical data stops behaving like the validation report promised.
+
+## Retraining Cadence
+
+A temporal backtest can help choose how often to retrain.
+
+Compare several retraining strategies:
+
+- Train once and keep the model fixed.
+- Retrain monthly with all available data.
+- Retrain monthly with a rolling window.
+- Retrain only when drift or performance triggers fire.
+- Retrain separate models for stable and fast-changing segments.
+
+For each strategy, simulate what would have happened historically. At each point, use only the data that would have been available then.
+
+This turns retraining cadence from a guess into an evaluated design choice.
+
+The best cadence depends on the rate of change, label delay, training cost, deployment risk, and governance requirements. Faster retraining is not always better. It can amplify label noise, chase temporary shocks, or increase operational complexity.
+
+## Temporal Validation for Classification
+
+For classification, temporal validation should report more than accuracy.
+
+Useful metrics include:
+
+- AUC or PR AUC by time window
+- Precision and recall by threshold
+- False positive and false negative rates
+- Calibration by period
+- Confusion matrices by period
+- Threshold stability
+- Error rates for new categories or entities
+- Abstention or review rates if the system can defer
+
+Thresholds deserve special attention. A threshold chosen on one period may not produce the same precision, recall, or workload in a later period if the base rate changes.
+
+For example, a fraud threshold that produces 1,000 alerts per day in March may produce 4,000 alerts per day in June after transaction volume or fraud prevalence changes. Temporal validation should measure that operational consequence.
+
+## Temporal Validation for Regression
+
+For regression, temporal validation should look at errors across time and target ranges.
+
+Useful metrics include:
+
+- Mean absolute error
+- Root mean squared error
+- Mean error or bias
+- Quantile loss
+- Prediction interval coverage
+- Error by horizon
+- Error by season or calendar period
+- Residual drift
+
+Forecasting problems need special care because errors often depend on horizon. One-day-ahead forecasts may be accurate while 30-day forecasts are weak. A single aggregate metric across horizons can hide this pattern.
+
+Regression models should also be checked for bias over time. A model that is unbiased overall may systematically underpredict during growth periods and overpredict during declines.
+
+## Backtesting Business Decisions
+
+Temporal validation should not stop at model metrics when decisions are available.
+
+If a model drives actions, evaluate the decision policy historically:
+
+- Which cases would have been approved, rejected, escalated, discounted, inspected, or contacted?
+- What cost or benefit would those actions have produced?
+- Would capacity constraints have been violated?
+- Would review queues have overloaded?
+- Would the model have treated important groups differently?
+- How quickly would performance have degraded between retraining cycles?
+
+This is often called policy backtesting or decision backtesting. It connects predictive performance to operational value.
+
+A model can have slightly worse AUC but better business performance if its errors are less costly or its threshold is more stable. Temporal validation is the natural place to see that.
+
+## Common Mistakes
+
+The first mistake is shuffling time-dependent data. This makes validation easier than deployment.
+
+The second mistake is using the row creation date when the true prediction time is different.
+
+The third mistake is computing features without point-in-time cutoffs.
+
+The fourth mistake is ignoring delayed labels and pretending outcomes were known earlier than they were.
+
+The fifth mistake is fitting preprocessing on the full dataset before splitting.
+
+The sixth mistake is evaluating only one future period and assuming it represents all future behavior.
+
+The seventh mistake is treating temporal validation as a time-series-only concern. Any changing production environment can require it.
+
+## A Practical Checklist
+
+Before trusting a temporal validation result, ask:
+
+- What is the exact prediction time?
+- What information is available at that time?
+- When does the label become observable?
+- Are features computed point-in-time?
+- Are preprocessing steps fit only on training periods?
+- Does the split match deployment?
+- Are new entities evaluated separately when relevant?
+- Are several future windows tested?
+- Are thresholds and calibration selected without future leakage?
+- Are model metrics connected to operational decisions?
+
+If the answer to any of these is unclear, the validation result may be optimistic.
+
+## Conclusion
+
+Temporal validation is the discipline of testing models against the future instead of against a shuffled version of the past.
+
+It matters because real machine learning systems operate in time. Data arrives, labels mature, behavior shifts, features change, and decisions must be made before outcomes are known.
+
+Good temporal validation respects that sequence. It uses time-based splits, point-in-time features, delayed-label logic, rolling backtests, realistic preprocessing, and deployment-matched horizons. It evaluates not only whether the model predicts well, but whether it remains useful as the world moves.
+
+For production machine learning, this is one of the most important habits a team can build. If the validation design lets the future leak into the past, the model has already passed a test it will never get in the real world.

--- a/_posts/2025-11-18-representation_learning_tabular_data.md
+++ b/_posts/2025-11-18-representation_learning_tabular_data.md
@@ -1,6 +1,4 @@
 ---
-redirect_from:
-- '/Machine Learning/Data Science/representation_learning_tabular_data/'
 title: "Representation Learning for Tabular Data: Beyond Manual Feature Engineering"
 categories:
 - Machine Learning
@@ -10,7 +8,7 @@ tags:
 - Neural Networks
 author_profile: false
 seo_title: "Representation Learning for Tabular Data"
-seo_description: "A practical guide to representation learning for tabular data, covering embeddings, feature interactions, inductive bias, gradient boosting, neural networks, and evaluation."
+seo_description: 'Representation learning for tabular data: embeddings, feature interactions, inductive bias, and how it compares to gradient boosting.'
 excerpt: "Representation learning for tabular data is not about replacing feature engineering blindly. It is about learning useful structure while respecting the constraints of business data."
 summary: "This article explains how representation learning applies to tabular machine learning. It discusses categorical embeddings, feature interactions, supervised and self-supervised representations, why gradient boosting remains strong, where neural networks help, and how to evaluate learned features without leaking information."
 keywords:

--- a/_posts/2025-12-10-selective_prediction_abstention_machine_learning.md
+++ b/_posts/2025-12-10-selective_prediction_abstention_machine_learning.md
@@ -1,6 +1,4 @@
 ---
-redirect_from:
-- '/Machine Learning/Data Science/selective_prediction_abstention_machine_learning/'
 title: "Selective Prediction in Machine Learning: When Models Should Abstain"
 categories:
 - Machine Learning
@@ -9,7 +7,7 @@ tags:
 - Risk Management
 author_profile: false
 seo_title: "Selective Prediction in Machine Learning"
-seo_description: "A practical guide to selective prediction in machine learning, covering abstention, confidence thresholds, risk-coverage trade-offs, calibration, human review, and deployment."
+seo_description: 'Selective prediction in machine learning: abstention, confidence thresholds, risk-coverage trade-offs, and routing to human review.'
 excerpt: "Selective prediction gives machine learning systems a third option: predict when confidence is adequate and abstain when the cost of being wrong is too high."
 summary: "This article explains selective prediction as a practical design pattern for reliable machine learning systems. It covers abstention, reject options, confidence scores, calibration, risk-coverage curves, conformal-style sets, human review, operational constraints, fairness risks, and monitoring."
 keywords:

--- a/_posts/2026-01-14-active_learning_label_efficiency_machine_learning.md
+++ b/_posts/2026-01-14-active_learning_label_efficiency_machine_learning.md
@@ -1,6 +1,4 @@
 ---
-redirect_from:
-- '/Machine Learning/Data Science/active_learning_label_efficiency_machine_learning/'
 title: "Active Learning for Machine Learning: Getting More Value from Fewer Labels"
 categories:
 - Machine Learning
@@ -9,7 +7,7 @@ tags:
 - Confidence Intervals
 author_profile: false
 seo_title: "Active Learning for Machine Learning"
-seo_description: "A practical guide to active learning in machine learning, covering label efficiency, uncertainty sampling, diversity, human review, data quality, and deployment."
+seo_description: 'Active learning for label efficiency: uncertainty sampling, diversity, and keeping data quality high under a limited labelling budget.'
 excerpt: "Active learning improves machine learning by choosing which examples to label, not merely by asking for more labeled data."
 summary: "This article explains active learning as a practical strategy for label-efficient machine learning. It covers uncertainty sampling, margin sampling, query by committee, diversity, representative sampling, human labeling workflows, validation design, failure modes, and when active learning is worth the operational cost."
 keywords:

--- a/_posts/2026-02-18-unsupervised_learning_early_data_drift_detection.md
+++ b/_posts/2026-02-18-unsupervised_learning_early_data_drift_detection.md
@@ -1,16 +1,14 @@
 ---
+redirect_from:
+- '/machine learning/data science/model monitoring/unsupervised_learning_early_data_drift_detection/'
 title: "Using Unsupervised Learning for Early Data Drift Detection"
 categories:
 - Machine Learning
-- Data Science
-- Model Monitoring
 tags:
 - Data Drift
 - Unsupervised Learning
 - Model Monitoring
-- Autoencoders
 - Clustering
-- Production Machine Learning
 author_profile: false
 seo_title: "Unsupervised Learning for Early Data Drift Detection"
 seo_description: "A practical article on using clustering, density estimation, embeddings, and autoencoders to detect data drift before model performance labels arrive."

--- a/_posts/2026-03-26-data_drift_and_fairness_monitoring_ai.md
+++ b/_posts/2026-03-26-data_drift_and_fairness_monitoring_ai.md
@@ -1,16 +1,13 @@
 ---
+redirect_from:
+- '/machine learning/data science/ai ethics/data_drift_and_fairness_monitoring_ai/'
 title: "Data Drift and Fairness: Monitoring Equity When Populations Change"
 categories:
 - Machine Learning
-- Data Science
-- AI Ethics
 tags:
 - Data Drift
-- Fairness
+- Ethics
 - Model Monitoring
-- Responsible AI
-- Bias Detection
-- Production Machine Learning
 author_profile: false
 seo_title: "Data Drift and Fairness in Production Machine Learning"
 seo_description: "A practical guide to monitoring model fairness under data drift, including subgroup performance, fairness metrics, delayed labels, alert design, and governance."

--- a/_posts/2026-04-09-slice_based_model_evaluation_machine_learning.md
+++ b/_posts/2026-04-09-slice_based_model_evaluation_machine_learning.md
@@ -1,18 +1,15 @@
 ---
+redirect_from:
+- '/machine learning/data science/slice_based_model_evaluation_machine_learning/'
 title: "Slice-Based Model Evaluation: Finding the Failures Average Metrics Hide"
 categories:
 - Machine Learning
-- Data Science
 tags:
 - Model Evaluation
-- Error Analysis
-- Slice Analysis
-- Machine Learning Monitoring
-- Model Reliability
-- Subgroup Analysis
+- Model Monitoring
 author_profile: false
 seo_title: "Slice-Based Model Evaluation for Machine Learning"
-seo_description: "A practical guide to slice-based model evaluation in machine learning, focused on subgroup performance, hidden failure modes, error analysis, monitoring, and reliable deployment."
+seo_description: 'Slice-based model evaluation: finding the subgroup failures that average metrics hide, and monitoring them in production.'
 excerpt: "Slice-based evaluation exposes where a machine learning model fails by breaking aggregate performance into meaningful subgroups, conditions, and operational contexts."
 summary: "This article explains slice-based model evaluation as a practical method for finding hidden machine learning failures. It covers why average metrics are insufficient, how to define useful slices, how to avoid noisy comparisons, how slice analysis connects to fairness and monitoring, and how to turn error analysis into model improvements."
 keywords:

--- a/_posts/2026-05-07-paired_vs_independent_samples_hypothesis_testing.md
+++ b/_posts/2026-05-07-paired_vs_independent_samples_hypothesis_testing.md
@@ -1,16 +1,11 @@
 ---
+redirect_from:
+- '/statistics/data analysis/hypothesis testing/paired_vs_independent_samples_hypothesis_testing/'
 title: "Paired vs. Independent Samples: The Design Choice Behind the Test"
 categories:
 - Statistics
-- Data Analysis
-- Hypothesis Testing
 tags:
-- Paired Samples
-- Independent Samples
-- T Test
-- Wilcoxon Signed-Rank Test
-- Mann-Whitney U Test
-- Study Design
+- Hypothesis Testing
 author_profile: false
 seo_title: "Paired vs Independent Samples in Hypothesis Testing"
 seo_description: "A practical guide to deciding whether data are paired or independent, and how that design choice affects t-tests, rank tests, effect sizes, and interpretation."

--- a/_posts/2026-07-29-fourier_analysis_for_data_science.md
+++ b/_posts/2026-07-29-fourier_analysis_for_data_science.md
@@ -1,16 +1,13 @@
 ---
+redirect_from:
+- '/mathematics/data science/signal processing/fourier_analysis_for_data_science/'
 title: "Fourier Analysis for Data Science: From Signals to Features"
 categories:
 - Mathematics
-- Data Science
-- Signal Processing
 tags:
-- Fourier Analysis
-- Fourier Transform
+- Signal Processing
 - Time Series
 - Feature Engineering
-- Signal Processing
-- Spectral Analysis
 author_profile: false
 seo_title: "Fourier Analysis for Data Science"
 seo_description: 'An accessible introduction to Fourier analysis for data science: periodicity, frequency-domain features, aliasing, and leakage.'

--- a/_posts/2026-08-15-cloud_edge_architecture_predictive_maintenance.md
+++ b/_posts/2026-08-15-cloud_edge_architecture_predictive_maintenance.md
@@ -1,16 +1,14 @@
 ---
+redirect_from:
+- '/data science/industrial analytics/predictive maintenance/cloud_edge_architecture_predictive_maintenance/'
 title: "Cloud Computing and Edge Analytics in Predictive Maintenance"
 categories:
 - Data Science
-- Industrial Analytics
-- Predictive Maintenance
 tags:
 - Predictive Maintenance
-- Edge Analytics
-- Cloud Computing
+- MLOps
 - Industrial IoT
 - Data Engineering
-- Streaming Analytics
 author_profile: false
 seo_title: "Cloud and Edge Architecture for Predictive Maintenance"
 seo_description: How cloud computing and edge analytics support predictive maintenance, covering latency, reliability, pipelines, and trade-offs.

--- a/_posts/2026-08-15-data_visualization_dashboards_predictive_maintenance.md
+++ b/_posts/2026-08-15-data_visualization_dashboards_predictive_maintenance.md
@@ -1,16 +1,14 @@
 ---
+redirect_from:
+- '/data science/industrial analytics/predictive maintenance/data_visualization_dashboards_predictive_maintenance/'
 title: "Data Visualization and Dashboards for Predictive Maintenance"
 categories:
 - Data Science
-- Industrial Analytics
-- Predictive Maintenance
 tags:
 - Predictive Maintenance
 - Data Visualization
-- Dashboards
+- Business Intelligence
 - Industrial IoT
-- Maintenance Planning
-- Decision Support
 author_profile: false
 seo_title: "Predictive Maintenance Dashboards and Data Visualization"
 seo_description: "A practical guide to designing predictive maintenance dashboards that connect sensor data, model outputs, asset health, and maintenance decisions."

--- a/_posts/2026-08-15-evaluating_roi_predictive_maintenance.md
+++ b/_posts/2026-08-15-evaluating_roi_predictive_maintenance.md
@@ -1,16 +1,12 @@
 ---
+redirect_from:
+- '/data science/industrial analytics/predictive maintenance/evaluating_roi_predictive_maintenance/'
 title: "Evaluating the ROI of Predictive Maintenance: A Practical Measurement Framework"
 categories:
 - Data Science
-- Industrial Analytics
-- Predictive Maintenance
 tags:
 - Predictive Maintenance
-- ROI
-- Maintenance Analytics
 - Industrial IoT
-- Asset Management
-- Decision Science
 author_profile: false
 seo_title: "How to Evaluate Predictive Maintenance ROI"
 seo_description: "A practical framework for measuring predictive maintenance ROI, including cost drivers, baseline design, benefit attribution, and common measurement mistakes."

--- a/_posts/2026-08-16-bayesian_decision_theory_data_science.md
+++ b/_posts/2026-08-16-bayesian_decision_theory_data_science.md
@@ -1,15 +1,12 @@
 ---
+redirect_from:
+- '/mathematics/statistics/data science/bayesian_decision_theory_data_science/'
 title: "Bayesian Decision Theory for Data Science: From Uncertainty to Action"
 categories:
 - Mathematics
-- Statistics
-- Data Science
 tags:
 - Bayesian Statistics
-- Decision Theory
-- Risk
-- Uncertainty
-- Experimentation
+- Confidence Intervals
 - Machine Learning
 author_profile: false
 seo_title: "Bayesian Decision Theory for Data Science"

--- a/_posts/2026-08-16-discrete_mathematics_for_data_science.md
+++ b/_posts/2026-08-16-discrete_mathematics_for_data_science.md
@@ -1,16 +1,14 @@
 ---
+redirect_from:
+- '/mathematics/data science/computer science/discrete_mathematics_for_data_science/'
 title: "Discrete Mathematics for Data Science: States, Constraints, and Algorithms"
 categories:
 - Mathematics
-- Data Science
-- Computer Science
 tags:
-- Discrete Mathematics
-- Algorithms
+- Mathematical Modeling
+- Machine Learning
 - Graph Theory
 - Combinatorics
-- Boolean Algebra
-- Data Structures
 author_profile: false
 seo_title: "Discrete Mathematics for Data Science"
 seo_description: "A practical introduction to discrete mathematics for data science, focused on states, constraints, graphs, logic, counting, and algorithmic thinking."

--- a/_posts/2026-08-16-information_geometry_data_science.md
+++ b/_posts/2026-08-16-information_geometry_data_science.md
@@ -1,6 +1,4 @@
 ---
-redirect_from:
-- '/Mathematics/Statistics/Data Science/information_geometry_data_science/'
 title: "Information Geometry for Data Science: Curvature, Models, and Learning"
 categories:
 - Mathematics
@@ -11,7 +9,7 @@ tags:
 - Optimization
 author_profile: false
 seo_title: "Information Geometry for Data Science"
-seo_description: "A practical introduction to information geometry for data science, covering statistical manifolds, Fisher information, curvature, natural gradients, and model behavior."
+seo_description: 'Information geometry for data science: statistical manifolds, Fisher information, curvature, and natural gradients.'
 excerpt: "Information geometry treats probability models as geometric objects, making it easier to reason about distance, curvature, uncertainty, and learning."
 summary: "This article introduces information geometry as a useful framework for data science. It explains statistical manifolds, Fisher information, KL divergence, curvature, natural gradients, model sensitivity, uncertainty, and why geometry matters when fitting, comparing, and deploying probabilistic models."
 keywords:

--- a/_posts/Economics/2020-01-01-mathematical_models_inequality_understanding_lorenz_curves_gini_coefficients.md
+++ b/_posts/Economics/2020-01-01-mathematical_models_inequality_understanding_lorenz_curves_gini_coefficients.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Mathematical Economics
+- Economics
 classes: wide
 date: '2020-01-01'
 excerpt: This article delves into mathematical models of inequality, focusing on the Lorenz curve and Gini coefficient to measure and interpret economic disparities.
@@ -23,24 +23,18 @@ keywords:
 - Python
 - Java
 - JavaScript
+redirect_from:
+- '/mathematical economics/mathematical_models_inequality_understanding_lorenz_curves_gini_coefficients/'
 seo_description: Explore mathematical models of inequality, including the Lorenz curve and Gini coefficient, and learn how they quantify economic inequality.
 seo_title: Lorenz Curves and Gini Coefficients Explained
 seo_type: article
 summary: A comprehensive guide to understanding and applying Lorenz curves and Gini coefficients to measure economic inequality.
 tags:
-- Lorenz curve
-- Gini coefficient
-- Economic inequality
 - Economics
 - Statistics
-- Inequality
-- Data science
+- Data Science
 - Python
-- Java
-- Javascript
-- python
-- java
-- javascript
+- Programming
 title: 'Mathematical Models of Inequality: Understanding Lorenz Curves and Gini Coefficients'
 ---
 

--- a/_posts/Economics/2020-07-26-solving_dsge_models_numerically.md
+++ b/_posts/Economics/2020-07-26-solving_dsge_models_numerically.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Mathematical Economics
+- Economics
 classes: wide
 date: '2020-07-26'
 excerpt: A guide to solving DSGE models numerically, focusing on perturbation techniques and finite difference methods used in economic modeling.
@@ -24,24 +24,18 @@ keywords:
 - Python
 - Fortran
 - C
+redirect_from:
+- '/mathematical economics/solving_dsge_models_numerically/'
 seo_description: Explore numerical methods for solving DSGE models, including perturbation techniques and finite difference methods, essential tools in quantitative economics.
 seo_title: Solving DSGE Models Numerically
 seo_type: article
 summary: This article covers numerical techniques for solving DSGE models, particularly perturbation and finite difference methods, essential in analyzing economic dynamics.
 tags:
-- Dsge models
-- Numerical methods
-- Perturbation techniques
-- Finite difference methods
 - Economics
-- Quantitative analysis
-- Computational methods
+- Numerical Methods
+- Mathematical Modeling
 - Python
-- Fortran
-- C
-- python
-- fortran
-- c
+- Programming
 title: 'Solving DSGE Models Numerically: Perturbation Techniques and Finite Difference Methods'
 ---
 

--- a/_posts/Economics/2022-01-01-exchange_rate_models_understanding_ppp_uip.md
+++ b/_posts/Economics/2022-01-01-exchange_rate_models_understanding_ppp_uip.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Mathematical Economics
+- Economics
 classes: wide
 date: '2022-01-01'
 excerpt: Explore exchange rate models like Purchasing Power Parity (PPP) and Uncovered Interest Parity (UIP), key frameworks in global economics.
@@ -17,14 +17,14 @@ keywords:
 - Purchasing power parity
 - Uncovered interest parity
 - Currency valuation
+redirect_from:
+- '/mathematical economics/exchange_rate_models_understanding_ppp_uip/'
 seo_description: Learn about exchange rate models such as Purchasing Power Parity (PPP) and Uncovered Interest Parity (UIP) and their role in international finance.
 seo_title: 'Exchange Rate Models: PPP and UIP Explained'
 seo_type: article
 summary: An overview of exchange rate models with a focus on Purchasing Power Parity (PPP) and Uncovered Interest Parity (UIP), including their principles, applications, and limitations.
 tags:
-- Exchange rates
-- Purchasing power parity
-- Uncovered interest parity
+- Economics
 title: 'Exchange Rate Models: Understanding PPP and UIP'
 ---
 

--- a/_posts/Economics/2024-07-14-copula_garch_other_financial_models.md
+++ b/_posts/Economics/2024-07-14-copula_garch_other_financial_models.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Mathematical Economics
+- Economics
 classes: wide
 date: '2024-07-14'
 excerpt: An in-depth look at financial models such as Copula and GARCH, their importance in quantitative analysis, and practical applications with Python.
@@ -22,18 +22,17 @@ keywords:
 - Finance
 - Statistics
 - Quantitative Analysis
+redirect_from:
+- '/mathematical economics/copula_garch_other_financial_models/'
 seo_description: Explore key financial models, including Copula and GARCH, for quantitative analysis in finance, with applications in risk assessment and Python code examples.
 seo_title: Copula, GARCH, and Financial Models in Quantitative Analysis
 seo_type: article
 summary: This article delves into financial modeling techniques like Copula and GARCH, covering their theoretical foundations and practical applications in finance.
 tags:
-- Copula
-- Garch
-- Financial models
-- Python
 - Finance
+- Python
 - Statistics
-- Quantitative Analysis
+- Mathematical Modeling
 title: Copula, GARCH, and Other Financial Models
 ---
 

--- a/_posts/Economics/2024-07-26-solow_growth_model_extensions.md
+++ b/_posts/Economics/2024-07-26-solow_growth_model_extensions.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Mathematical Economics
+- Economics
 classes: wide
 date: '2024-07-26'
 excerpt: An exploration of the Solow Growth Model's extensions, including the effects of technological advancement and human capital on economic growth.
@@ -21,18 +21,15 @@ keywords:
 - Economics
 - Growth Theory
 - Quantitative Analysis
+redirect_from:
+- '/mathematical economics/solow_growth_model_extensions/'
 seo_description: Explore extensions to the Solow Growth Model, incorporating technological progress and human capital to understand long-term economic growth.
 seo_title: 'Solow Growth Model: Technology and Human Capital'
 seo_type: article
 summary: This article delves into the Solow Growth Model and its extensions, examining how technological change and human capital influence economic growth.
 tags:
-- Solow growth model
-- Economic growth
-- Technological change
-- Human capital
 - Economics
-- Growth Theory
-- Quantitative Analysis
+- Mathematical Modeling
 title: 'Solow Growth Model and Extensions: Technological Change and Human Capital'
 ---
 

--- a/_posts/Economics/2024-10-25-measuring_income_inequality_via_percentile_relativities_a_comprehensive_exploration.md
+++ b/_posts/Economics/2024-10-25-measuring_income_inequality_via_percentile_relativities_a_comprehensive_exploration.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Mathematical Economics
+- Economics
 classes: wide
 date: '2024-10-25'
 excerpt: This article delves deeply into percentile relativity indices, a novel approach to measuring income inequality, offering fresh insights into income distribution and its societal implications.
@@ -21,18 +21,16 @@ keywords:
 - Statistics
 - Social sciences
 - Python
+redirect_from:
+- '/mathematical economics/measuring_income_inequality_via_percentile_relativities_a_comprehensive_exploration/'
 seo_description: Percentile-based measures of income inequality compared with the Gini Index, including approaches from Brazauskas, Greselin, and Zitikis.
 seo_title: Measuring Income Inequality via Percentile Relativities
 seo_type: article
 summary: This article explores the measurement of income inequality through percentile relativities, comparing it with traditional metrics like the Gini Index. It discusses new inequality indices, their application in real-world data, and their policy implications.
 tags:
-- Income inequality
-- Percentile relativities
-- Gini index
-- Statistical measures
-- Inequality indices
+- Economics
+- Descriptive Statistics
 - Statistics
-- Social sciences
 - Python
 title: 'Measuring Income Inequality via Percentile Relativities: A Comprehensive Exploration'
 ---

--- a/_posts/Economics/2024-11-18-optimal_control_theory_in_economics.md
+++ b/_posts/Economics/2024-11-18-optimal_control_theory_in_economics.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Mathematical Economics
+- Economics
 classes: wide
 date: '2024-11-18'
 excerpt: Optimal control theory, employing Hamiltonian and Lagrangian methods, offers powerful tools in modeling and optimizing fiscal and monetary policy.
@@ -19,16 +19,14 @@ keywords:
 - Hamiltonian economics
 - Lagrangian economics
 - Economics
+redirect_from:
+- '/mathematical economics/optimal_control_theory_in_economics/'
 seo_description: How Hamiltonian and Lagrangian techniques apply to economic models, particularly for optimizing fiscal and monetary policy.
 seo_title: Optimal Control Theory in Economics
 seo_type: article
 summary: This article examines the application of Hamiltonian and Lagrangian techniques in optimal control theory for fiscal and monetary policy, exploring their significance in economic modeling.
 tags:
-- Optimal control theory
-- Hamiltonian method
-- Lagrangian method
-- Fiscal policy
-- Monetary policy
+- Economics
 title: 'Optimal Control Theory in Economics: Hamiltonian and Lagrangian Techniques in Fiscal and Monetary Policy Models'
 ---
 

--- a/_posts/Economics/2024-11-20-the_rich_get_richer_the_physics_of_wealth_distribution_and_inequality.md
+++ b/_posts/Economics/2024-11-20-the_rich_get_richer_the_physics_of_wealth_distribution_and_inequality.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Mathematical Economics
+- Economics
 classes: wide
 date: '2024-11-20'
 excerpt: The rich are getting richer while the poor remain poor. This article dives into the physics-based models that explain the inherent inequality in wealth distribution.
@@ -32,31 +32,19 @@ keywords:
 - Boltzmann-Gibbs Distribution
 - Game Theory
 - Endogenous Growth
+redirect_from:
+- '/mathematical economics/the_rich_get_richer_the_physics_of_wealth_distribution_and_inequality/'
 seo_description: An in-depth exploration of the economic and physical models explaining wealth distribution, focusing on Pareto's Law and the emerging field of econophysics.
 seo_title: The Physics of Wealth Distribution
 seo_type: article
 summary: This article examines the growing inequality between the rich and poor, utilizing models from physics and econophysics to explain how wealth distribution follows specific statistical patterns. It discusses key findings from physicists and economists and their implications for future policy and societal structure.
 tags:
-- Wealth distribution
-- Inequality
-- Econophysics
-- Pareto law
-- Income disparity
-- Physics
-- Social Sciences
+- Probability
+- Economics
+- Mathematical Modeling
 - Python
 - Data Science
-- Wealth Inequality
-- Pareto Distribution
-- Stochastic Models
-- Agent-Based Models
-- Markov Chains
-- Lorenz Curve
-- Gini Coefficient
-- Wealth Distribution Models
-- Differential Equations
-- Game Theory
-- Endogenous Growth Models
+- Artificial Intelligence
 title: 'The Rich Get Richer: The Physics of Wealth Distribution and Inequality'
 ---
 

--- a/_posts/Economics/2024-12-01-forecasting_commodity_prices_using_machine_learning_techniques_and_applications.md
+++ b/_posts/Economics/2024-12-01-forecasting_commodity_prices_using_machine_learning_techniques_and_applications.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Mathematical Economics
+- Economics
 classes: wide
 date: '2024-12-01'
 excerpt: Explore how machine learning can be leveraged to forecast commodity prices, such as oil and gold, using advanced predictive models and economic indicators.
@@ -21,17 +21,15 @@ keywords:
 - Markdown
 - Data Science
 - Machine Learning
+redirect_from:
+- '/mathematical economics/forecasting_commodity_prices_using_machine_learning_techniques_and_applications/'
 seo_description: How machine learning forecasts commodity prices such as oil and gold using predictive models and economic indicators.
 seo_title: Forecasting Commodity Prices with Machine Learning
 seo_type: article
 summary: This article delves into the application of machine learning techniques to forecast commodity prices, such as oil and gold. It discusses the methods, economic indicators used, and the challenges in building predictive models in this complex domain.
 tags:
-- Commodity prices
-- Machine learning
-- Predictive modeling
-- Economic indicators
-- Data science in economics
-- Markdown
+- Machine Learning
+- Economics
 - Data Science
 title: 'Forecasting Commodity Prices Using Machine Learning: Techniques and Applications'
 ---

--- a/_posts/biographies/2019-12-23-john_nash_game_theory_and_the_beautiful_mind.md
+++ b/_posts/biographies/2019-12-23-john_nash_game_theory_and_the_beautiful_mind.md
@@ -23,10 +23,8 @@ seo_title: 'John Nash: Game Theory and the Mind Behind the Mathematics'
 seo_type: article
 summary: John Nash, the mathematical genius who revolutionized game theory and economics, is also remembered for his personal battle with schizophrenia. This biography delves into his contributions to mathematics and economics, as well as his complex personal journey, which became the basis of the film *A Beautiful Mind*.
 tags:
-- John nash
-- Game theory
+- Game Theory
 - Economics
-- Schizophrenia
 title: 'John Nash: Game Theory and the Beautiful Mind'
 ---
 

--- a/_posts/biographies/2019-12-24-sophie_germain_pioneer_in_number_theory_and_elasticity.md
+++ b/_posts/biographies/2019-12-24-sophie_germain_pioneer_in_number_theory_and_elasticity.md
@@ -23,10 +23,8 @@ seo_title: 'Sophie Germain: Trailblazer in Number Theory and Elasticity'
 seo_type: article
 summary: Sophie Germain overcame significant social barriers in the early 19th century to become a leading mathematician in number theory and elasticity. This article delves into her personal struggles, her notable achievements in mathematics, and her legacy in scientific history.
 tags:
-- Sophie germain
-- Number theory
-- Elasticity
-- Women in science
+- Number Theory
+- Biographies
 title: 'Sophie Germain: Pioneer in Number Theory and Elasticity'
 ---
 

--- a/_posts/biographies/2019-12-25-ada_lovelace_the_first_computer_programmer.md
+++ b/_posts/biographies/2019-12-25-ada_lovelace_the_first_computer_programmer.md
@@ -23,10 +23,7 @@ seo_title: 'Ada Lovelace: The First Computer Programmer'
 seo_type: article
 summary: Ada Lovelace is recognized as the first computer programmer, thanks to her collaboration with Charles Babbage on the Analytical Engine and her groundbreaking work on algorithms and computational theory. This extensive article explores her life, contributions, and lasting impact on the world of computing.
 tags:
-- Ada lovelace
-- Computer science
-- History of computing
-- Analytical engine
+- Programming
 title: 'Ada Lovelace: The First Computer Programmer'
 ---
 

--- a/_posts/biographies/2019-12-26-formulator_of_mathematical_problems.md
+++ b/_posts/biographies/2019-12-26-formulator_of_mathematical_problems.md
@@ -23,11 +23,8 @@ seo_title: David Hilbert and the Hilbert Problems
 seo_type: article
 summary: David Hilbert revolutionized mathematics with his famous 'Hilbert Problems,' foundational contributions in algebra and geometry, and efforts to formalize mathematics through logic. His ideas shaped the course of mathematical thought in the 20th century.
 tags:
-- David hilbert
-- Hilbert problems
-- Algebra
 - Geometry
-- Mathematical logic
+- Mathematical Modeling
 title: 'David Hilbert: The Formulator of Mathematical Problems'
 ---
 

--- a/_posts/biographies/2019-12-27-kurt_godel_incompleteness_theorem_limits_mathematics.md
+++ b/_posts/biographies/2019-12-27-kurt_godel_incompleteness_theorem_limits_mathematics.md
@@ -23,15 +23,7 @@ seo_title: 'Kurt Gödel: Incompleteness Theorems and Mathematical Logic'
 seo_type: article
 summary: Kurt Gödel, one of the greatest logicians of the 20th century, is best known for his incompleteness theorems, which demonstrated the limitations of formal systems in mathematics. This article delves into his life, his revolutionary ideas, and his close relationship with Albert Einstein.
 tags:
-- Kurt Gödel
-- Incompleteness Theorem
-- Mathematical Logic
-- Gödel and Einstein
-- Philosophy of mathematics
-- Vienna Circle
-- Hilbert's Program
-- Gödel's rotating universe solution
-- Platonism in mathematics
+- Mathematical Modeling
 title: 'Kurt Gödel: Incompleteness Theorem and the Limits of Mathematics'
 ---
 

--- a/_posts/biographies/2019-12-28-hypatia_of_alexandria_the_first_known_female_mathematician.md
+++ b/_posts/biographies/2019-12-28-hypatia_of_alexandria_the_first_known_female_mathematician.md
@@ -23,11 +23,9 @@ seo_title: 'Hypatia of Alexandria: The First Known Female Mathematician'
 seo_type: article
 summary: Learn about Hypatia of Alexandria, the first known female mathematician. Discover her contributions to mathematics and astronomy, her philosophical influence, and the enduring legacy of her work in science and philosophy.
 tags:
-- Hypatia of alexandria
-- Ancient mathematics
+- Mathematical Modeling
 - Geometry
-- Astronomy
-- Women in science
+- Biographies
 title: 'Hypatia of Alexandria: The First Known Female Mathematician'
 ---
 

--- a/_posts/biographies/2020-01-12-grace_hopper_pioneer_of_computer_science_and_programming_languages.md
+++ b/_posts/biographies/2020-01-12-grace_hopper_pioneer_of_computer_science_and_programming_languages.md
@@ -23,12 +23,8 @@ seo_title: 'Grace Hopper: Pioneer of COBOL and Computing'
 seo_type: article
 summary: Grace Hopper, a pioneer in computer science, is best known for developing the first compiler for programming languages and playing a critical role in the creation of COBOL. Her work transformed how computers are programmed and coined the term 'debugging' for fixing computer issues.
 tags:
-- Grace hopper
-- Computer science
-- Programming languages
-- Cobol
-- Compiler development
-- Women in stem
+- Programming
+- Biographies
 title: 'Grace Hopper: Pioneer of Computer Science and Programming Languages'
 ---
 

--- a/_posts/biographies/2020-12-25-katherine_johnson_the_mathematician_who_helped_launch_america_into_space.md
+++ b/_posts/biographies/2020-12-25-katherine_johnson_the_mathematician_who_helped_launch_america_into_space.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Biographies
 classes: wide
 date: '2020-12-25'
 excerpt: Katherine Johnson was a trailblazing mathematician at NASA whose calculations for the Mercury and Apollo missions helped guide U.S. space exploration. Learn about her groundbreaking contributions to applied mathematics.
@@ -19,17 +18,15 @@ keywords:
 - Apollo missions calculations
 - Mercury space missions
 - Women pioneers in stem
+redirect_from:
+- '/mathematics/biographies/katherine_johnson_the_mathematician_who_helped_launch_america_into_space/'
 seo_description: Katherine Johnson, the NASA mathematician whose trajectory calculations were critical to the Mercury and Apollo missions.
 seo_title: 'Katherine Johnson: The NASA Mathematician'
 seo_type: article
 summary: Katherine Johnson was a brilliant mathematician whose work at NASA included calculating trajectories for the Mercury and Apollo space missions. Her contributions to applied mathematics were essential to the success of U.S. space exploration, making her a key figure in American scientific history.
 tags:
-- Katherine johnson
-- Nasa
-- Women in stem
-- Mercury program
-- Apollo space missions
-- Applied mathematics
+- Biographies
+- Mathematical Modeling
 title: 'Katherine Johnson: The Mathematician Who Helped Launch America into Space'
 ---
 

--- a/_posts/biographies/2021-01-27-julia_robinson_mathematician_and_pioneer_in_decision_problems.md
+++ b/_posts/biographies/2021-01-27-julia_robinson_mathematician_and_pioneer_in_decision_problems.md
@@ -23,11 +23,8 @@ seo_title: 'Julia Robinson and Hilbert''s Tenth Problem'
 seo_type: article
 summary: This article delves into the life and legacy of Julia Robinson, a pioneering mathematician who contributed significantly to solving Hilbert's Tenth Problem. Learn about her groundbreaking work in decision problems and her impact on mathematics.
 tags:
-- Julia robinson
-- Number theory
-- Decision problems
-- Hilbert's tenth problem
-- Women in mathematics
+- Number Theory
+- Mathematical Modeling
 title: 'Julia Robinson: Mathematician and Pioneer in Decision Problems'
 ---
 

--- a/_posts/biographies/2022-05-26-dorothy_vaughan_pioneering_mathematician_and_nasa_computer_scientist.md
+++ b/_posts/biographies/2022-05-26-dorothy_vaughan_pioneering_mathematician_and_nasa_computer_scientist.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Biographies
 classes: wide
 date: '2022-05-26'
 excerpt: Dorothy Vaughan was a pioneering mathematician and computer scientist who led NASA's computing division and became a leader in FORTRAN programming. She overcame racial and gender barriers to contribute to the U.S. space program.
@@ -19,17 +18,15 @@ keywords:
 - African american women in stem
 - Fortran programming expert
 - Hidden figures
+redirect_from:
+- '/mathematics/biographies/dorothy_vaughan_pioneering_mathematician_and_nasa_computer_scientist/'
 seo_description: 'Dorothy Vaughan, who led NASA''s computing division and became a FORTRAN expert while facing significant barriers.'
 seo_title: 'Dorothy Vaughan: Pioneering Mathematician and Leader at NASA'
 seo_type: article
 summary: Dorothy Vaughan was a groundbreaking mathematician and computer scientist who led the computing division at NASA during a pivotal time in the space race. She became an expert in FORTRAN programming and broke barriers as an African American woman in STEM.
 tags:
-- Dorothy vaughan
-- Nasa
-- Fortran
-- Women in stem
-- African american mathematicians
-- Computer science
+- Biographies
+- Programming
 title: 'Dorothy Vaughan: Pioneering Mathematician and NASA Computer Scientist'
 ---
 

--- a/_posts/biographies/2023-07-23-maryam_mirzakhani_the_first_woman_to_win_the_fields_medal.md
+++ b/_posts/biographies/2023-07-23-maryam_mirzakhani_the_first_woman_to_win_the_fields_medal.md
@@ -23,11 +23,9 @@ seo_title: 'Maryam Mirzakhani: First Woman to Win the Fields Medal'
 seo_type: article
 summary: Maryam Mirzakhani was the first woman to win the Fields Medal, recognized for her pioneering work on the dynamics and geometry of Riemann surfaces and their moduli spaces. Her legacy continues to inspire the world of mathematics.
 tags:
-- Maryam mirzakhani
-- Fields medal
-- Hyperbolic geometry
-- Riemann surfaces
-- Women in mathematics
+- Biographies
+- Geometry
+- Mathematical Modeling
 title: 'Maryam Mirzakhani: The First Woman to Win the Fields Medal'
 ---
 

--- a/_posts/biographies/2024-01-07-marina_viazovska_fields_medalist_and_pioneer_in_sphere_packing.md
+++ b/_posts/biographies/2024-01-07-marina_viazovska_fields_medalist_and_pioneer_in_sphere_packing.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Mathematics
-- Biographies
 classes: wide
 date: '2024-01-07'
 excerpt: Marina Viazovska won the Fields Medal in 2022 for her remarkable solution to the sphere packing problem in 8 dimensions and her contributions to Fourier analysis and modular forms.
@@ -20,18 +19,17 @@ keywords:
 - E8 lattice
 - Fourier analysis contributions
 - Women in mathematics
+redirect_from:
+- '/mathematics/biographies/marina_viazovska_fields_medalist_and_pioneer_in_sphere_packing/'
 seo_description: How Marina Viazovska solved sphere packing in 8 dimensions and won the 2022 Fields Medal for her work in discrete geometry.
 seo_title: 'Marina Viazovska: Fields Medalist and Sphere Packing Pioneer'
 seo_type: article
 summary: Marina Viazovska is a Ukrainian mathematician who won the Fields Medal in 2022 for solving the sphere packing problem in 8 dimensions. Her elegant methods and groundbreaking work in discrete geometry and Fourier analysis continue to influence the field.
 tags:
-- Marina viazovska
-- Fields medal
-- Sphere packing
-- E8 lattice
-- Discrete geometry
-- Fourier analysis
-- Women in mathematics
+- Biographies
+- Geometry
+- Signal Processing
+- Mathematical Modeling
 title: 'Marina Viazovska: Fields Medalist and Pioneer in Sphere Packing'
 ---
 

--- a/_posts/biographies/2024-10-21-mary_jackson_nasas_first_black_female_engineer_and_advocate_for_diversity.md
+++ b/_posts/biographies/2024-10-21-mary_jackson_nasas_first_black_female_engineer_and_advocate_for_diversity.md
@@ -24,13 +24,8 @@ seo_title: 'Mary Jackson: NASA''s First Black Female Engineer'
 seo_type: article
 summary: Mary Jackson, NASA’s first Black female engineer, was a trailblazer in aerospace engineering and a lifelong advocate for equality and inclusion in STEM. Her work helped shape NASA’s early space missions, and her commitment to diversity created opportunities for future generations.
 tags:
-- Mary Jackson
-- NASA
-- Women in STEM
-- Aerospace Engineering
-- Diversity and Inclusion
-- African American Mathematicians
-- Mathematics
+- Biographies
+- Mathematical Modeling
 title: 'Mary Jackson: NASA''s First Black Female Engineer and Advocate for Diversity'
 ---
 

--- a/_posts/biographies/2024-11-01-mary_somerville_pioneer_astronomy_mathematical_physics.md
+++ b/_posts/biographies/2024-11-01-mary_somerville_pioneer_astronomy_mathematical_physics.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Science History
+- Data Science
 classes: wide
 date: '2024-11-01'
 excerpt: Mary Somerville's work in astronomy and mathematical physics earned her recognition as one of the first female scientists, making complex scientific concepts accessible.
@@ -17,15 +17,15 @@ keywords:
 - Women scientists
 - Astronomy history
 - Mathematical physics
+redirect_from:
+- '/science history/mary_somerville_pioneer_astronomy_mathematical_physics/'
 seo_description: Mary Somerville, a pioneering scientist in astronomy and mathematical physics who brought science to a wider public.
 seo_title: 'Mary Somerville: Astronomy and Mathematical Physics'
 seo_type: article
 summary: Discover Mary Somerville's life and legacy as a trailblazer in science, whose accessible writings in astronomy and physics inspired generations.
 tags:
-- Mary somerville
-- Astronomy
-- Mathematical physics
-- Women in science
+- Mathematical Modeling
+- Biographies
 title: 'Mary Somerville: Pioneer in Astronomy and Mathematical Physics'
 ---
 

--- a/_posts/biographies/2024-11-02-emmy_noether_revolutionizing_abstract_algebra_and_theoretical_physics.md
+++ b/_posts/biographies/2024-11-02-emmy_noether_revolutionizing_abstract_algebra_and_theoretical_physics.md
@@ -25,12 +25,8 @@ seo_title: 'Emmy Noether: Abstract Algebra and Physics'
 seo_type: article
 summary: Discover the life and legacy of Emmy Noether, a visionary mathematician whose contributions to algebra and theoretical physics continue to shape modern science.
 tags:
-- Emmy Noether
-- Abstract Algebra
-- Noether's Theorem
-- Women in Science
-- Mathematics
-- Physics
+- Biographies
+- Mathematical Modeling
 title: 'Emmy Noether: Revolutionizing Abstract Algebra and Theoretical Physics'
 ---
 

--- a/_posts/data science/2019-12-29-understanding_splines_what_they_how_they_used_data_analysis.md
+++ b/_posts/data science/2019-12-29-understanding_splines_what_they_how_they_used_data_analysis.md
@@ -28,13 +28,10 @@ seo_title: What Are Splines? Uses in Data Analysis
 seo_type: article
 summary: Splines are flexible mathematical functions used to approximate complex patterns in data. They help smooth data, model non-linear relationships, and fit curves in regression analysis. This article covers the basics of splines, their various types, and their practical applications in statistics, data science, and machine learning.
 tags:
-- Splines
 - Regression
-- Data smoothing
-- Nonlinear models
+- Signal Processing
 - Python
-- Bash
-- Go
+- Programming
 - Statistics
 - Machine Learning
 title: 'Understanding Splines: What They Are and How They Are Used in Data Analysis'

--- a/_posts/data science/2019-12-30-evaluating_binary_classifiers_imbalanced_datasets.md
+++ b/_posts/data science/2019-12-30-evaluating_binary_classifiers_imbalanced_datasets.md
@@ -23,10 +23,8 @@ seo_title: AUC-PR vs. AUC-ROC on Imbalanced Data
 seo_type: article
 summary: In this article, we explore why AUC-PR (Area Under Precision-Recall Curve) is a superior metric for evaluating binary classifiers on imbalanced datasets compared to AUC-ROC and Gini. We discuss how class imbalance distorts performance metrics and provide real-world examples of why Precision-Recall curves give a clearer understanding of model performance on rare events.
 tags:
-- Binary classifiers
-- Imbalanced data
-- Auc-pr
-- Precision-recall
+- Classification
+- Model Evaluation
 title: 'Evaluating Binary Classifiers on Imbalanced Datasets: Why AUC-PR Beats AUC-ROC and Gini'
 ---
 

--- a/_posts/data science/2020-01-06-role_data_science_predictive_maintenance.md
+++ b/_posts/data science/2020-01-06-role_data_science_predictive_maintenance.md
@@ -24,11 +24,9 @@ seo_title: How Data Science Powers Predictive Maintenance
 seo_type: article
 summary: An in-depth look at how data science techniques such as regression, clustering, anomaly detection, and machine learning are transforming predictive maintenance across various industries.
 tags:
-- Predictive maintenance
-- Machine learning
-- Industrial iot
-- Industrial analytics
-- Predictive analytics
+- Predictive Maintenance
+- Machine Learning
+- Industrial IoT
 title: Leveraging Data Science Techniques for Predictive Maintenance
 ---
 

--- a/_posts/data science/2024-06-08-iot_and_data_science_for_climate_action.md
+++ b/_posts/data science/2024-06-08-iot_and_data_science_for_climate_action.md
@@ -25,12 +25,10 @@ seo_title: Using IoT and Data Science for Climate Action
 seo_type: article
 summary: Explore how IoT devices and data science combine to monitor and analyze environmental data, providing essential insights to support climate action and sustainability.
 tags:
-- Iot
-- Climate change
-- Environmental monitoring
-- Climate Action
+- Industrial IoT
+- Climate and Environment
+- Model Monitoring
 - Data Science
-- Internet of Things
 title: 'IoT and Data Science for Climate Action: Monitoring, Analysis, and Insights'
 ---
 

--- a/_posts/industrial_mathematics/2025-09-05-applications_mathematics_machine_learning_industrial_management.md
+++ b/_posts/industrial_mathematics/2025-09-05-applications_mathematics_machine_learning_industrial_management.md
@@ -1,15 +1,14 @@
 ---
+redirect_from:
+- '/industrial management/data science/artificial intelligence/applications_mathematics_machine_learning_industrial_management/'
 title: "Applications of Mathematics and Machine Learning in Industrial Management: A Comprehensive Review"
 categories:
-  - Industrial Management
-  - Data Science
-  - Artificial Intelligence
+- Data Science
 tags:
-  - Machine Learning
-  - Mathematical Optimization
-  - Industry 4.0
-  - Supply Chain
-  - Predictive Maintenance
+- Machine Learning
+- Optimization
+- Supply Chain
+- Predictive Maintenance
 author_profile: false
 seo_title: Mathematics and Machine Learning in Industrial Management
 seo_description: How mathematical optimization and machine learning are transforming supply chain, production, and quality control.

--- a/_posts/machine_learning/2020-01-01-model_drift—why_even_the_best_machine_learning_models_fail_over_time.md
+++ b/_posts/machine_learning/2020-01-01-model_drift—why_even_the_best_machine_learning_models_fail_over_time.md
@@ -24,11 +24,8 @@ seo_title: 'Model Drift in Production: Case Studies'
 seo_type: article
 summary: This article explores model drift, its causes, real-world impact, and strategies to detect and mitigate its effects in production machine learning systems.
 tags:
-- Model drift
-- Data drift
-- Concept drift
-- Ml model monitoring
-- Ai lifecycle
+- Data Drift
+- Model Monitoring
 title: 'Model Drift in Production: Case Studies'
 ---
 

--- a/_posts/machine_learning/2020-01-08-role_machine_learning_predicting_climate_change_impacts.md
+++ b/_posts/machine_learning/2020-01-08-role_machine_learning_predicting_climate_change_impacts.md
@@ -24,11 +24,8 @@ seo_title: Machine Learning and Climate Change
 seo_type: article
 summary: This article examines the role of machine learning in predicting climate change impacts, focusing on extreme weather events, sea-level rise, and biodiversity loss.
 tags:
-- Machine learning
-- Climate change
-- Predictive analytics
-- Extreme weather
-- Biodiversity
+- Machine Learning
+- Climate and Environment
 title: The Role of Machine Learning in Predicting Climate Change Impacts
 ---
 

--- a/_posts/machine_learning/2022-05-18-understanding_incremental_learning_time_series_forecasting.md
+++ b/_posts/machine_learning/2022-05-18-understanding_incremental_learning_time_series_forecasting.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Data Science
-- Time Series
 classes: wide
 date: '2022-05-18'
 excerpt: Discover incremental learning in time series forecasting, a technique that dynamically updates models with new data for better accuracy and efficiency.
@@ -20,16 +18,16 @@ keywords:
 - Time Series Forecasting
 - Sherman-Morrison Formula
 - python
+redirect_from:
+- '/machine learning/data science/time series/understanding_incremental_learning_time_series_forecasting/'
 seo_description: How incremental learning enables continuous model updates in time series forecasting without full retraining.
 seo_title: Incremental Learning for Time Series Forecasting
 seo_type: article
 summary: This article discusses incremental learning, its applications to time series forecasting, and how methods like the Sherman–Morrison formula support dynamic model updates without retraining.
 tags:
-- Incremental Learning
-- Online Learning
-- Time Series Forecasting
-- Dynamic Model Updating
-- python
+- Supervised Learning
+- Time Series
+- Python
 title: Understanding Incremental Learning in Time Series Forecasting
 ---
 

--- a/_posts/machine_learning/2023-05-26-understanding_fowlkes_mallows_index.md
+++ b/_posts/machine_learning/2023-05-26-understanding_fowlkes_mallows_index.md
@@ -27,10 +27,8 @@ seo_title: The Fowlkes-Mallows Index in Clustering
 seo_type: article
 summary: Learn about the Fowlkes-Mallows Index, a statistical tool for assessing clustering and classification accuracy, its applications, and how it aids in validating algorithm performance.
 tags:
-- Fowlkes-mallows index
 - Clustering
 - Classification
-- Fmi
 - Machine Learning
 - Data Science
 title: 'Understanding the Fowlkes-Mallows Index: A Tool for Clustering and Classification Evaluation'

--- a/_posts/machine_learning/2024-11-12-exploring_liquid_state_machine.md
+++ b/_posts/machine_learning/2024-11-12-exploring_liquid_state_machine.md
@@ -2,8 +2,6 @@
 author_profile: false
 categories:
 - Machine Learning
-- Computational Neuroscience
-- Neural Networks
 classes: wide
 date: '2024-11-12'
 excerpt: The Liquid State Machine offers a unique framework for computations within biological neural networks and adaptive artificial intelligence. Explore its fundamentals, theoretical background, and practical applications.
@@ -20,17 +18,15 @@ keywords:
 - Biological computation
 - Reservoir computing
 - python
+redirect_from:
+- '/machine learning/computational neuroscience/neural networks/exploring_liquid_state_machine/'
 seo_description: The Liquid State Machine, a computational model inspired by biological neural networks, and its applications.
 seo_title: The Liquid State Machine Explained
 seo_type: article
 summary: This comprehensive guide to the Liquid State Machine (LSM) model explores its foundations, significance in biological computations, and applications in machine learning, providing a deep dive into how LSMs leverage neural plasticity and random circuits for advanced computations.
 tags:
-- Liquid state machine
-- Spiking neural networks
-- Biological computation
-- Reservoir computing
-- Neural modeling
-- python
+- Neural Networks
+- Python
 title: 'Exploring the Liquid State Machine: A Computational Model for Neural Networks and Beyond'
 ---
 

--- a/_posts/machine_learning/2024-12-01-statistical_ai.md
+++ b/_posts/machine_learning/2024-12-01-statistical_ai.md
@@ -1,7 +1,7 @@
 ---
 author_profile: false
 categories:
-- Artificial Intelligence
+- Machine Learning
 classes: wide
 excerpt: Statistical AI leverages probabilistic reasoning and data-driven inference to build adaptive and intelligent systems.
 keywords:
@@ -10,15 +10,16 @@ keywords:
 - Probabilistic Models
 - Machine Learning
 - Hidden Markov Models
+redirect_from:
+- '/artificial intelligence/statistical_ai/'
 seo_description: An in-depth exploration of statistical AI, its probabilistic foundations, classic models, and how it powers modern machine learning.
 seo_title: 'Statistical AI: The Probabilistic Foundations'
 summary: This article explores Statistical AI, focusing on its mathematical foundations, key statistical models, machine learning applications, and its role in advancing artificial intelligence.
 tags:
-- AI
-- Statistical Learning
+- Artificial Intelligence
 - Machine Learning
 - Probability
-- Bayesian Inference
+- Bayesian Statistics
 title: 'Statistical AI: Probabilistic Foundations of Artificial Intelligence'
 ---
 

--- a/_posts/machine_learning/2025-05-26-improving_elderly_mental_health_machine_learning.md
+++ b/_posts/machine_learning/2025-05-26-improving_elderly_mental_health_machine_learning.md
@@ -1,15 +1,12 @@
 ---
+redirect_from:
+- '/healthcare ai/mental health/aging population/improving_elderly_mental_health_machine_learning/'
 title: "Improving Elderly Mental Health with Machine Learning and Data Analytics: Transforming Care for an Aging Population"
 categories:
-- Healthcare AI
-- Mental Health
-- Aging Population
+- Healthcare
 tags:
-- elderly mental health
-- machine learning
-- healthcare innovation
-- cognitive decline
-- AI applications
+- Healthcare
+- Machine Learning
 author_profile: false
 seo_title: "Improving Elderly Mental Health with AI & Data Analytics"
 seo_description: How machine learning and analytics are transforming elderly mental health care, from early detection to clinical integration.

--- a/_posts/machine_learning/2025-08-24-data_drift_concept_drift_understanding_differences_implications-.md
+++ b/_posts/machine_learning/2025-08-24-data_drift_concept_drift_understanding_differences_implications-.md
@@ -1,14 +1,13 @@
 ---
+redirect_from:
+- '/machine learning/model monitoring/data_drift_concept_drift_understanding_differences_implications/'
 title: 'Data Drift vs. Concept Drift: Understanding the Differences and Implications'
 categories:
-  - Machine Learning
-  - Model Monitoring
+- Machine Learning
 tags:
-  - data drift
-  - concept drift
-  - MLOps
-  - AI reliability
-  - model monitoring
+- Data Drift
+- MLOps
+- Model Monitoring
 author_profile: false
 seo_title: Data Drift vs. Concept Drift in Machine Learning
 seo_description: The differences between data drift and concept drift, how each affects models in production, and how to detect them.

--- a/_posts/machine_learning/2025-08-25-ai_and_machine_learning_renewable_energy_optimization.md
+++ b/_posts/machine_learning/2025-08-25-ai_and_machine_learning_renewable_energy_optimization.md
@@ -1,14 +1,12 @@
 ---
+redirect_from:
+- '/renewable energy/artificial intelligence/machine learning/ai_and_machine_learning_renewable_energy_optimization/'
 title: "AI and Machine Learning in Renewable Energy Optimization: Powering the Future of Sustainable Energy"
 categories:
-- Renewable Energy
-- Artificial Intelligence
-- Machine Learning
+- Environment
 tags:
-- AI
-- ML
-- Smart Grid
-- Energy Storage
+- Artificial Intelligence
+- Climate and Environment
 - Forecasting
 header:
   image: /assets/images/data_science_11.jpg

--- a/_posts/mathematics/2019-12-27-calculus_understanding_derivatives_and_integrals.md
+++ b/_posts/mathematics/2019-12-27-calculus_understanding_derivatives_and_integrals.md
@@ -22,10 +22,7 @@ seo_title: 'Calculus: Exploring Derivatives and Integrals'
 seo_type: article
 summary: Calculus is a branch of mathematics that focuses on change and accumulation. This article explores the key concepts of derivatives and integrals, explaining how they are used to solve problems in fields like physics, economics, and engineering.
 tags:
-- Calculus
-- Derivatives
-- Integrals
-- Mathematics
+- Mathematical Modeling
 title: 'Calculus: Understanding Derivatives and Integrals'
 ---
 

--- a/_posts/statistics/2015-07-26-correlation_vs_causation_understanding_relationships_between_variables.md
+++ b/_posts/statistics/2015-07-26-correlation_vs_causation_understanding_relationships_between_variables.md
@@ -25,10 +25,9 @@ seo_type: article
 summary: This article breaks down the essential difference between correlation and causation, covering how correlation coefficients measure relationship strength and how controlled experiments establish causality.
 tags:
 - Correlation
-- Causation
-- Data analysis
+- Data Analysis
 - Statistics
-- Rust
+- Programming
 - R
 title: 'Correlation vs. Causation: Understanding Relationships Between Variables'
 ---

--- a/_posts/statistics/2016-07-26-understanding_distribution_descriptions_their_importance_statistics.md
+++ b/_posts/statistics/2016-07-26-understanding_distribution_descriptions_their_importance_statistics.md
@@ -2,7 +2,6 @@
 author_profile: false
 categories:
 - Statistics
-- Data Science
 classes: wide
 date: '2016-07-26'
 excerpt: Dive into the intricacies of describing distributions, understand the mathematics behind common distributions, and see their applications in parametric statistics across multiple disciplines.
@@ -19,15 +18,16 @@ keywords:
 - Parametric
 - Data analysis
 - Normal distribution
+redirect_from:
+- '/statistics/data science/understanding_distribution_descriptions_their_importance_statistics/'
 seo_description: How to describe statistical distributions, their mathematical properties, and applications in finance, medicine, and engineering.
 seo_title: Describing Distributions for Parametric Statistics
 seo_type: article
 summary: This article explains the role of distribution descriptions in parametric statistics, examining key distributions, their parameters, and the importance of distributional assumptions in real-world data analysis.
 tags:
 - Statistics
-- Data analysis
-- Distributions
-- Parametric statistics
+- Data Analysis
+- Probability
 title: A Comprehensive Guide to Describing Distributions and Their Role in Parametric Statistics
 ---
 

--- a/_posts/statistics/2019-12-28-shapirowilk_test_vs_andersondarling_checking_normality_small_large_samples.md
+++ b/_posts/statistics/2019-12-28-shapirowilk_test_vs_andersondarling_checking_normality_small_large_samples.md
@@ -25,10 +25,8 @@ seo_title: Shapiro-Wilk vs Anderson-Darling Normality Tests
 seo_type: article
 summary: This article compares the Shapiro-Wilk and Anderson-Darling tests, emphasizing how sample size and distribution characteristics influence the choice of method when assessing normality.
 tags:
-- Normality testing
-- Shapiro-wilk test
-- Anderson-darling test
-- Sample size
+- Hypothesis Testing
+- Sample Size
 - Python
 title: 'Shapiro-Wilk Test vs. Anderson-Darling: Checking for Normality in Small vs. Large Samples'
 ---

--- a/_posts/statistics/2019-12-31-deep_dive_into_why_multiple_imputation_indefensible.md
+++ b/_posts/statistics/2019-12-31-deep_dive_into_why_multiple_imputation_indefensible.md
@@ -22,9 +22,7 @@ seo_title: 'The Case Against Multiple Imputation: An In-depth Look'
 seo_type: article
 summary: Multiple imputation is widely regarded as the gold standard for handling missing data, but it carries significant conceptual and interpretative challenges. We will explore its weaknesses and propose an alternative using single stochastic imputation and deterministic sensitivity analysis.
 tags:
-- Multiple imputation
-- Missing data
-- Data imputation
+- Missing Data
 title: A Deep Dive into Why Multiple Imputation is Indefensible
 ---
 

--- a/_posts/statistics/2019-12-31-machine_learning_statistics_bridging_gap.md
+++ b/_posts/statistics/2019-12-31-machine_learning_statistics_bridging_gap.md
@@ -23,10 +23,9 @@ seo_title: How Statistical Methods Power Machine Learning
 seo_type: article
 summary: Machine learning and statistics share deep connections. This article examines the ways statistical methods form the backbone of machine learning algorithms, exploring key techniques like regression, decision trees, and support vector machines.
 tags:
-- Machine learning
+- Machine Learning
 - Statistics
-- Algorithms
-- Data science
+- Data Science
 title: 'Machine Learning and Statistics: Bridging the Gap'
 ---
 

--- a/_posts/statistics/2020-01-01-causality_correlation.md
+++ b/_posts/statistics/2020-01-01-causality_correlation.md
@@ -23,11 +23,8 @@ seo_title: 'Causality Beyond Correlation: Paradoxes and Graphs'
 seo_type: article
 summary: An in-depth exploration of the limits of correlation in data interpretation, highlighting Simpson's and Berkson's paradoxes and introducing causal graphs as a tool for uncovering true causal relationships.
 tags:
-- Simpson's paradox
-- Berkson's paradox
 - Correlation
-- Data science
-- Causal inference
+- Data Science
 title: 'Causality Beyond Correlation: Simpson''s and Berkson''s Paradoxes'
 ---
 

--- a/_posts/statistics/2020-01-02-maximum_likelihood_estimation_statistical_modeling.md
+++ b/_posts/statistics/2020-01-02-maximum_likelihood_estimation_statistical_modeling.md
@@ -25,11 +25,10 @@ seo_title: 'MLE: A Key Tool in Data Science'
 seo_type: article
 summary: This article covers the essentials of Maximum Likelihood Estimation (MLE), breaking down its mathematical foundation, importance in data science, practical applications, and limitations.
 tags:
-- Statistical modeling
-- Bash
-- Maximum likelihood estimation
-- Data science
-- Mle
+- Statistical Modeling
+- Programming
+- Probability
+- Data Science
 - Python
 title: 'Maximum Likelihood Estimation (MLE): Statistical Modeling in Data Science'
 ---

--- a/_posts/statistics/2020-01-03-assessing_goodnessoffit_nonparametric_data.md
+++ b/_posts/statistics/2020-01-03-assessing_goodnessoffit_nonparametric_data.md
@@ -23,11 +23,9 @@ seo_title: Kolmogorov-Smirnov Test for Goodness-of-Fit
 seo_type: article
 summary: This article explains the Kolmogorov-Smirnov (K-S) test for assessing the goodness-of-fit of non-parametric data. We compare the K-S test to other goodness-of-fit tests, such as Shapiro-Wilk, and provide real-world use cases, including testing whether a dataset follows a specific distribution.
 tags:
-- Kolmogorov-smirnov test
-- Goodness-of-fit tests
-- Non-parametric data
-- Shapiro-wilk test
-- Distribution fitting
+- Hypothesis Testing
+- Nonparametric Methods
+- Probability
 title: 'Kolmogorov-Smirnov Test: Assessing Goodness-of-Fit in Non-Parametric Data'
 ---
 

--- a/_posts/statistics/2020-01-04-multiple_comparisons_problem_bonferroni_correction_other_solutions.md
+++ b/_posts/statistics/2020-01-04-multiple_comparisons_problem_bonferroni_correction_other_solutions.md
@@ -24,11 +24,6 @@ seo_title: The Multiple Comparisons Problem and Bonferroni
 seo_type: article
 summary: This article explores the multiple comparisons problem in hypothesis testing, discussing solutions like the Bonferroni correction, Holm-Bonferroni method, and False Discovery Rate (FDR). It includes practical examples from experiments involving multiple testing, such as medical studies and genetics.
 tags:
-- Multiple comparisons problem
-- Bonferroni correction
-- Holm-bonferroni
-- False discovery rate (fdr)
-- Multiple testing
 - Python
 title: 'Multiple Comparisons Problem: Bonferroni Correction and Other Solutions'
 ---

--- a/_posts/statistics/2020-01-05-oneway_anova_vs_twoway_anova_when_use_which.md
+++ b/_posts/statistics/2020-01-05-oneway_anova_vs_twoway_anova_when_use_which.md
@@ -23,11 +23,7 @@ seo_title: 'One-Way ANOVA vs. Two-Way ANOVA: When to Use Which'
 seo_type: article
 summary: This article discusses one-way and two-way ANOVA, focusing on when to use each method. It explains how two-way ANOVA is useful for analyzing interactions between factors and details the interpretation of main effects and interactions.
 tags:
-- One-way anova
-- Two-way anova
-- Interaction effects
-- Main effects
-- Hypothesis testing
+- Hypothesis Testing
 title: 'One-Way ANOVA vs. Two-Way ANOVA: When to Use Which'
 ---
 

--- a/_posts/statistics/2023-03-01-chisquare_test_testing_categorical_data.md
+++ b/_posts/statistics/2023-03-01-chisquare_test_testing_categorical_data.md
@@ -22,10 +22,8 @@ seo_title: Chi-Square Test for Categorical Data
 seo_type: article
 summary: An exploration of the Chi-Square Test, focusing on its use in testing the association between categorical variables and examining goodness-of-fit in statistical analysis.
 tags:
-- Categorical data
-- Chi-square test
-- Independence test
-- Goodness-of-fit
+- Data Analysis
+- Hypothesis Testing
 title: 'Chi-Square Test: Testing Categorical Data'
 ---
 

--- a/_posts/statistics/2024-10-22-understanding_coverage_probability_in_statistical_estimation.md
+++ b/_posts/statistics/2024-10-22-understanding_coverage_probability_in_statistical_estimation.md
@@ -30,18 +30,12 @@ seo_title: Coverage Probability and Confidence Intervals
 seo_type: article
 summary: This article delves into the concept of coverage probability in statistical estimation theory, focusing on confidence intervals and prediction intervals. It explains how coverage probability is calculated and why it is vital in determining the accuracy and reliability of statistical estimations.
 tags:
-- Coverage probability
-- Confidence intervals
-- Estimation theory
-- Statistical analysis
-- Uncertainty quantification
+- Probability
+- Confidence Intervals
+- Statistical Modeling
 - Data Science
-- Probability Theory
 - Python
-- Rust
-- R
-- Go
-- Scala
+- Programming
 title: Understanding Coverage Probability in Statistical Estimation
 ---
 

--- a/_posts/statistics/2024-11-05-capturemarkrecapture_reliable_method_estimating_wildlife_populations.md
+++ b/_posts/statistics/2024-11-05-capturemarkrecapture_reliable_method_estimating_wildlife_populations.md
@@ -28,14 +28,8 @@ seo_title: Capture-Mark-Recapture and its Statistical Reliability
 seo_type: article
 summary: This article delves into the statistical reliability of Capture-Mark-Recapture (CMR) methods in wildlife population estimation. It explains the six critical assumptions that must be fulfilled to achieve accurate results, and discusses the consequences of violating these assumptions, highlighting the importance of careful study design.
 tags:
-- Capture-mark-recapture
-- Wildlife statistics
-- Population estimation
-- Sampling methods
-- Ecological statistics
-- Statistical models
-- Biostatistics
-- Statistical assumptions
+- Statistics
+- Statistical Modeling
 title: Is Capture-Mark-Recapture a Reliable Method for Estimating Wildlife Populations?
 ---
 

--- a/_posts/statistics/2024-12-01-state_space_models_time_series_analysis_discretization_kalman_filter_bayesian_approaches.md
+++ b/_posts/statistics/2024-12-01-state_space_models_time_series_analysis_discretization_kalman_filter_bayesian_approaches.md
@@ -28,14 +28,12 @@ seo_title: 'State Space Models: Kalman Filter and Bayesian Methods'
 seo_type: article
 summary: State Space Models (SSMs) are fundamental in time series analysis, providing a framework for modeling dynamic systems. In this article, we delve into the process of discretization, examine the Kalman filter algorithm, and explore the application of Bayesian SSMs, particularly in macroeconometrics. These approaches allow for more accurate analysis and forecasting in complex, evolving systems.
 tags:
-- State space models
-- Time series analysis
-- Kalman filter
-- Bayesian statistics
-- Control theory
-- Dynamic systems
-- Econometrics
-- Discretization in ssm
+- Time Series
+- Signal Processing
+- Bayesian Statistics
+- Numerical Methods
+- Economics
+- Feature Engineering
 title: 'State Space Models (SSMs) in Time Series Analysis: Discretization, Kalman Filter, and Bayesian Approaches'
 ---
 

--- a/_posts/statistics/2024-12-07-chisquare_test_exploring_categorical_data_goodness_fit.md
+++ b/_posts/statistics/2024-12-07-chisquare_test_exploring_categorical_data_goodness_fit.md
@@ -22,9 +22,8 @@ seo_title: 'Chi-Square Test: Applications and Limits'
 seo_type: article
 summary: An in-depth exploration of the Chi-Square Test, focusing on its uses for goodness-of-fit and independence testing in categorical data analysis.
 tags:
-- Chi-square test
-- Goodness-of-fit
-- Categorical data
+- Hypothesis Testing
+- Data Analysis
 title: 'The Chi-Square Test in Practice: Applications and Limits'
 ---
 


### PR DESCRIPTION
Tags and categories had grown without a controlled vocabulary — 1471 tags (1152 used exactly once) and 156 categories spread over 148 distinct URL paths.

**Tags** — mapped onto a 71-term vocabulary. Used-once tags drop 1152 → 1; posts average 3.2 tags instead of 6.3. No URL impact (`jekyll-archives` is disabled, so tags aren't in permalinks).

**Categories** — one category per post, from 12. This kills the nested paths, which ran up to 7 segments deep (`/mathematics/statistics/data science/machine learning/<slug>/`).

187 URLs unchanged, **211 changed and redirect from their old location**. Added `jekyll-redirect-from` to serve them.

I harvested the old URLs from a build of the pre-change site rather than reconstructing them, because Jekyll downcases categories and slugifies titles — my hand-built paths had the wrong case and mangled slugs containing apostrophes, spaces, and em dashes, which would have 404ed on GitHub Pages.

Also: renamed a post whose filename ended in a space before `.md` (it produced a URL ending in a space and broke the build), and trimmed 6 over-long `seo_description` values.

Verified against a full build: 211 old URLs resolve correctly, 0 dead, 0 mistargeted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates site taxonomy to a controlled vocabulary and simplifies URLs. Tags drop from 1471 to 71 terms (average per post 6.3 → 3.2); categories drop from 156 to 12 with one category per post. Old behavior used deep, nested category paths; new behavior uses flat, single-category paths with redirects to preserve existing links.

- Tags: no URL impact because `jekyll-archives` is disabled.
- Categories: 187 URLs unchanged; 211 changed and now redirect via `redirect_from`. Added `jekyll-redirect-from` to serve legacy paths.
- Harvested old URLs from a pre-change build to avoid case/slug mismatches on case-sensitive hosts.
- Also fixed a filename with a trailing space that broke builds and trimmed six over-long `seo_description` values.
- Verified a full build: 211 legacy URLs resolve correctly, none dead or mistargeted.

**Review and rollout**
- Confirm `jekyll-redirect-from` is added in Gemfile, `_config.yml` plugins, and safe-mode whitelist; run `bundle install`.
- Spot-check a few posts for correct category/tag mapping and corresponding `redirect_from` entries.
- Build locally and test a sample of legacy URLs to ensure redirects work.
- No content migration required; external links continue to work through redirects.

<sup>Written for commit c3abc2c9757de70d3c58b4566e314a3e80d0c4e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/DiogoRibeiro7.github.io/pull/389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

