### PR TITLE
Add package project pages and a papers page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,6 +10,8 @@ main:
     url: /machine-learning/
   - title: "Time Series"
     url: /time-series/
+  - title: "Papers"
+    url: /papers/
   # - title: "Quick-Start Guide"
   #   url: https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/
   # - title: "About"

--- a/_pages/package-pinn-rk.md
+++ b/_pages/package-pinn-rk.md
@@ -1,0 +1,35 @@
+---
+layout: single
+title: "pinn-rk"
+permalink: /packages/pinn-rk/
+author_profile: true
+seo_title: "pinn-rk Python Package"
+seo_description: "Project page for pinn-rk, a PyTorch package for Runge-Kutta physics-informed neural networks."
+---
+
+`pinn-rk` provides Runge-Kutta physics-informed neural networks with time-discrete losses in PyTorch. It focuses on Gauss, Radau and Lobatto style formulations for scientific machine learning problems where temporal discretization is part of the modelling choice.
+
+## Install
+
+```bash
+pip install pinn-rk
+```
+
+## Project Links
+
+- **PyPI:** [pinn-rk](https://pypi.org/project/pinn-rk/)
+- **Documentation:** [diogoribeiro7.github.io/pinn-rk](https://diogoribeiro7.github.io/pinn-rk)
+- **Source:** [github.com/DiogoRibeiro7/pinn-rk](https://github.com/DiogoRibeiro7/pinn-rk)
+- **Issues:** [github.com/DiogoRibeiro7/pinn-rk/issues](https://github.com/DiogoRibeiro7/pinn-rk/issues)
+- **Discussions:** [github.com/DiogoRibeiro7/pinn-rk/discussions](https://github.com/DiogoRibeiro7/pinn-rk/discussions)
+- **Changelog:** [CHANGELOG.md](https://github.com/DiogoRibeiro7/pinn-rk/blob/main/CHANGELOG.md)
+
+## Package Metadata
+
+- **Current release:** `0.6.0`
+- **Requires Python:** `>=3.10,<3.13`
+- **License:** MIT
+
+## Where It Fits
+
+Use this package when the learning problem depends on time-stepping choices, numerical integration structure or a physics-informed loss that should be explicit and inspectable.

--- a/_pages/package-pinnlab.md
+++ b/_pages/package-pinnlab.md
@@ -1,0 +1,34 @@
+---
+layout: single
+title: "pinnlab"
+permalink: /packages/pinnlab/
+author_profile: true
+seo_title: "pinnlab Python Package"
+seo_description: "Project page for pinnlab, a Python package for physics-informed neural network experiments."
+---
+
+`pinnlab` is a Python package for physics-informed neural network experiments, aimed at workflows where neural approximators, differential equations, boundary conditions and reproducible examples need to live together.
+
+## Install
+
+```bash
+pip install pinnlab
+```
+
+## Project Links
+
+- **PyPI:** [pinnlab](https://pypi.org/project/pinnlab/)
+- **Documentation:** [GitHub README](https://github.com/DiogoRibeiro7/pinn#readme)
+- **Source:** [github.com/DiogoRibeiro7/pinn](https://github.com/DiogoRibeiro7/pinn)
+- **Issues:** [github.com/DiogoRibeiro7/pinn/issues](https://github.com/DiogoRibeiro7/pinn/issues)
+- **Changelog:** [CHANGELOG.md](https://github.com/DiogoRibeiro7/pinn/blob/main/CHANGELOG.md)
+
+## Package Metadata
+
+- **Current release:** `0.6.1`
+- **Requires Python:** `>=3.10`
+- **License:** MIT
+
+## Where It Fits
+
+Use this package as part of the scientific machine learning stack, especially for experiments that need explicit modelling assumptions rather than a purely black-box neural network.

--- a/_pages/package-setqca.md
+++ b/_pages/package-setqca.md
@@ -1,0 +1,33 @@
+---
+layout: single
+title: "setqca"
+permalink: /packages/setqca/
+author_profile: true
+seo_title: "setqca Python Package"
+seo_description: "Project page for setqca, a Python toolkit for crisp-set and fuzzy-set Qualitative Comparative Analysis."
+---
+
+`setqca` is a native Python toolkit for crisp-set and fuzzy-set Qualitative Comparative Analysis. It is research-methods software: the goal is to support configurational explanation, case comparison and transparent set-theoretic reasoning.
+
+## Install
+
+```bash
+pip install setqca
+```
+
+## Project Links
+
+- **PyPI:** [setqca](https://pypi.org/project/setqca/)
+- **Documentation:** [diogoribeiro7.github.io/setqca-python](https://diogoribeiro7.github.io/setqca-python/)
+- **Source:** [github.com/DiogoRibeiro7/setqca-python](https://github.com/DiogoRibeiro7/setqca-python)
+- **Issues:** [github.com/DiogoRibeiro7/setqca-python/issues](https://github.com/DiogoRibeiro7/setqca-python/issues)
+- **Changelog:** [CHANGELOG.md](https://github.com/DiogoRibeiro7/setqca-python/blob/main/CHANGELOG.md)
+
+## Package Metadata
+
+- **Current release:** `0.2.0`
+- **Requires Python:** `>=3.11,<4.0`
+
+## Where It Fits
+
+Use this package when the analysis is about necessary and sufficient conditions, configurations of causes, fuzzy-set calibration or comparative case logic rather than conventional prediction alone.

--- a/_pages/package-tscv-vision.md
+++ b/_pages/package-tscv-vision.md
@@ -1,0 +1,33 @@
+---
+layout: single
+title: "tscv-vision"
+permalink: /packages/tscv-vision/
+author_profile: true
+seo_title: "tscv-vision Python Package"
+seo_description: "Project page for tscv-vision, a NumPy-first package for structured time-series representation engineering."
+---
+
+`tscv-vision` is a NumPy-first package for structured representation engineering in time-series work. It gives reusable transformations a package home instead of leaving them scattered across notebooks.
+
+## Install
+
+```bash
+pip install tscv-vision
+```
+
+## Project Links
+
+- **PyPI:** [tscv-vision](https://pypi.org/project/tscv-vision/)
+- **Documentation:** [GitHub README](https://github.com/DiogoRibeiro7/tscv-vision#readme)
+- **Source:** [github.com/DiogoRibeiro7/tscv-vision](https://github.com/DiogoRibeiro7/tscv-vision)
+- **Issues:** [github.com/DiogoRibeiro7/tscv-vision/issues](https://github.com/DiogoRibeiro7/tscv-vision/issues)
+
+## Package Metadata
+
+- **Current release:** `0.4.0`
+- **Requires Python:** `>=3.10,<3.13`
+- **License:** MIT
+
+## Where It Fits
+
+Use this package for time-series feature and representation work where transformations need to be repeatable, testable and independent from a single modelling notebook.

--- a/_pages/package-wifi-activity-recognition.md
+++ b/_pages/package-wifi-activity-recognition.md
@@ -1,0 +1,34 @@
+---
+layout: single
+title: "wifi-activity-recognition"
+permalink: /packages/wifi-activity-recognition/
+author_profile: true
+seo_title: "wifi-activity-recognition Python Package"
+seo_description: "Project page for wifi-activity-recognition, a Python package for human activity recognition using WiFi CSI and computer vision workflows."
+---
+
+`wifi-activity-recognition` is a Python package for human activity recognition using WiFi channel-state information and computer vision workflows. It sits at the intersection of sensing, signal processing and applied machine learning.
+
+## Install
+
+```bash
+pip install wifi-activity-recognition
+```
+
+## Project Links
+
+- **PyPI:** [wifi-activity-recognition](https://pypi.org/project/wifi-activity-recognition/)
+- **Documentation:** [GitHub README](https://github.com/diogoribeiro7/wifi-csi-activity-recognition#readme)
+- **Source:** [github.com/diogoribeiro7/wifi-csi-activity-recognition](https://github.com/diogoribeiro7/wifi-csi-activity-recognition)
+- **Issues:** [github.com/diogoribeiro7/wifi-csi-activity-recognition/issues](https://github.com/diogoribeiro7/wifi-csi-activity-recognition/issues)
+- **Changelog:** [CHANGELOG.md](https://github.com/diogoribeiro7/wifi-csi-activity-recognition/blob/main/CHANGELOG.md)
+
+## Package Metadata
+
+- **Current release:** `0.2.0`
+- **Requires Python:** `>=3.10`
+- **License:** MIT
+
+## Where It Fits
+
+Use this package for activity-recognition experiments where WiFi CSI signals and vision-style modelling workflows need a reusable implementation surface.

--- a/_pages/packages.md
+++ b/_pages/packages.md
@@ -12,7 +12,7 @@ header:
   og_image: /assets/images/data_science_1.jpg
 seo_type: article
 seo_title: "Open Source Projects and Packages"
-seo_description: "Open-source Python and R packages by Diogo Ribeiro, including PyPI packages for survival simulation, physics-informed neural networks, QCA, time-series representations and WiFi activity recognition."
+seo_description: "Open-source Python and R packages for survival simulation, physics-informed neural networks, QCA and time-series representations."
 ---
 
 ## Open Source Projects & Packages
@@ -25,21 +25,21 @@ The Python projects below are published on PyPI under [DiogoRibeiro7](https://py
 
 | Package | Current release | Install | Purpose |
 | --- | --- | --- | --- |
-| [wifi-activity-recognition](https://pypi.org/project/wifi-activity-recognition/) | 0.2.0 | `pip install wifi-activity-recognition` | Human activity recognition using WiFi CSI and computer vision workflows. |
-| [tscv-vision](https://pypi.org/project/tscv-vision/) | 0.4.0 | `pip install tscv-vision` | NumPy-first structured representation engineering for time series. |
-| [pinnlab](https://pypi.org/project/pinnlab/) | 0.6.1 | `pip install pinnlab` | Physics-informed neural network implementations. |
-| [setqca](https://pypi.org/project/setqca/) | 0.2.0 | `pip install setqca` | Native Python toolkit for crisp-set and fuzzy-set qualitative comparative analysis. |
-| [gen-surv](https://pypi.org/project/gen-surv/) | 2.0.0 | `pip install gen-surv` | Survival-data simulation and visualization for statistical research and benchmarking. |
-| [pinn-rk](https://pypi.org/project/pinn-rk/) | 0.6.0 | `pip install pinn-rk` | Runge-Kutta physics-informed neural networks with time-discrete losses in PyTorch. |
+| [wifi-activity-recognition](/packages/wifi-activity-recognition/) | 0.2.0 | `pip install wifi-activity-recognition` | Human activity recognition using WiFi CSI and computer vision workflows. |
+| [tscv-vision](/packages/tscv-vision/) | 0.4.0 | `pip install tscv-vision` | NumPy-first structured representation engineering for time series. |
+| [pinnlab](/packages/pinnlab/) | 0.6.1 | `pip install pinnlab` | Physics-informed neural network implementations. |
+| [setqca](/packages/setqca/) | 0.2.0 | `pip install setqca` | Native Python toolkit for crisp-set and fuzzy-set qualitative comparative analysis. |
+| [gen-surv](/packages/gensurvpy/) | 2.0.0 | `pip install gen-surv` | Survival-data simulation and visualization for statistical research and benchmarking. |
+| [pinn-rk](/packages/pinn-rk/) | 0.6.0 | `pip install pinn-rk` | Runge-Kutta physics-informed neural networks with time-discrete losses in PyTorch. |
 
 ### Scientific Machine Learning
 
-#### [pinnlab](https://pypi.org/project/pinnlab/)
+#### [pinnlab](/packages/pinnlab/)
 
 Physics-informed neural network implementations for experiments where differential equations, boundary conditions and neural approximators need to live in the same workflow.
 
+- **Project page:** [pinnlab](/packages/pinnlab/)
 - **PyPI:** [pinnlab](https://pypi.org/project/pinnlab/)
-- **Documentation:** [DiogoRibeiro7.github.io/pinn](https://DiogoRibeiro7.github.io/pinn)
 - **Source:** [github.com/DiogoRibeiro7/pinn](https://github.com/DiogoRibeiro7/pinn)
 - **Requires Python:** `>=3.10`
 
@@ -47,12 +47,12 @@ Physics-informed neural network implementations for experiments where differenti
 pip install pinnlab
 ```
 
-#### [pinn-rk](https://pypi.org/project/pinn-rk/)
+#### [pinn-rk](/packages/pinn-rk/)
 
 Runge-Kutta PINNs for time-discrete physics-informed learning, including Gauss, Radau and Lobatto style losses in PyTorch.
 
+- **Project page:** [pinn-rk](/packages/pinn-rk/)
 - **PyPI:** [pinn-rk](https://pypi.org/project/pinn-rk/)
-- **Documentation:** [diogoribeiro7.github.io/pinn-rk](https://diogoribeiro7.github.io/pinn-rk)
 - **Source:** [github.com/DiogoRibeiro7/pinn-rk](https://github.com/DiogoRibeiro7/pinn-rk)
 - **Requires Python:** `>=3.10,<3.13`
 
@@ -76,12 +76,12 @@ A Python package for simulating survival data and producing visualizations under
 pip install gen-surv
 ```
 
-#### [setqca](https://pypi.org/project/setqca/)
+#### [setqca](/packages/setqca/)
 
 A native Python toolkit for crisp-set and fuzzy-set Qualitative Comparative Analysis. It belongs with the research-methods part of the site because it helps encode configurational arguments, not just fit predictive models.
 
+- **Project page:** [setqca](/packages/setqca/)
 - **PyPI:** [setqca](https://pypi.org/project/setqca/)
-- **Documentation:** [diogoribeiro7.github.io/setqca-python](https://diogoribeiro7.github.io/setqca-python/)
 - **Source:** [github.com/DiogoRibeiro7/setqca-python](https://github.com/DiogoRibeiro7/setqca-python)
 - **Requires Python:** `>=3.11,<4.0`
 
@@ -91,12 +91,12 @@ pip install setqca
 
 ### Time Series, Signals and Activity Recognition
 
-#### [tscv-vision](https://pypi.org/project/tscv-vision/)
+#### [tscv-vision](/packages/tscv-vision/)
 
 Structured representation engineering for time series with a NumPy-first API. This package is a better fit for reusable transformations and experiments than one-off notebook code.
 
+- **Project page:** [tscv-vision](/packages/tscv-vision/)
 - **PyPI:** [tscv-vision](https://pypi.org/project/tscv-vision/)
-- **Documentation:** [GitHub README](https://github.com/DiogoRibeiro7/tscv-vision#readme)
 - **Source:** [github.com/DiogoRibeiro7/tscv-vision](https://github.com/DiogoRibeiro7/tscv-vision)
 - **Requires Python:** `>=3.10,<3.13`
 
@@ -104,12 +104,12 @@ Structured representation engineering for time series with a NumPy-first API. Th
 pip install tscv-vision
 ```
 
-#### [wifi-activity-recognition](https://pypi.org/project/wifi-activity-recognition/)
+#### [wifi-activity-recognition](/packages/wifi-activity-recognition/)
 
 A package for human activity recognition using WiFi channel-state information and computer vision workflows. It sits at the intersection of sensing, signal processing and applied machine learning.
 
+- **Project page:** [wifi-activity-recognition](/packages/wifi-activity-recognition/)
 - **PyPI:** [wifi-activity-recognition](https://pypi.org/project/wifi-activity-recognition/)
-- **Documentation:** [wifi-activity-recognition.readthedocs.io](https://wifi-activity-recognition.readthedocs.io/)
 - **Source:** [github.com/diogoribeiro7/wifi-csi-activity-recognition](https://github.com/diogoribeiro7/wifi-csi-activity-recognition)
 - **Requires Python:** `>=3.10`
 

--- a/_pages/papers.md
+++ b/_pages/papers.md
@@ -1,0 +1,45 @@
+---
+layout: single
+title: "Papers & Research Repositories"
+permalink: /papers/
+author_profile: true
+seo_title: "Papers and Public Research Repositories"
+seo_description: "Published, drafted and reproducible research manuscripts by Diogo Ribeiro with public repositories, source files, PDFs and replication code."
+---
+
+This page collects papers, draft manuscripts, reports and reproducible research repositories that have public source material. Status labels are conservative: a repository is listed as a draft or reproducible report unless the public metadata clearly identifies a publication.
+
+## Manuscripts and Drafts
+
+| Work | Status | Repository | Manuscript |
+| --- | --- | --- | --- |
+| Stochastic diffusion processes, Brownian paths and implicit volatility coefficients | Draft manuscript | [sml_diffusions_paper](https://github.com/DiogoRibeiro7/sml_diffusions_paper) | [PDF](https://github.com/DiogoRibeiro7/sml_diffusions_paper/blob/main/paper/main.pdf), [LaTeX](https://github.com/DiogoRibeiro7/sml_diffusions_paper/blob/main/paper/main.tex) |
+| Article TeX repository | Draft manuscript source | [article_tex_repo](https://github.com/DiogoRibeiro7/article_tex_repo) | [PDF](https://github.com/DiogoRibeiro7/article_tex_repo/blob/main/main.pdf), [LaTeX](https://github.com/DiogoRibeiro7/article_tex_repo/blob/main/main.tex) |
+| Short-rate innovations, monetary regimes and stock-market anomalies | Reproducible manuscript | [short-rate-anomaly-regimes](https://github.com/DiogoRibeiro7/short-rate-anomaly-regimes) | [PDF](https://github.com/DiogoRibeiro7/short-rate-anomaly-regimes/blob/main/paper/manuscript.pdf), [LaTeX](https://github.com/DiogoRibeiro7/short-rate-anomaly-regimes/blob/main/paper/manuscript.tex) |
+| Regime-conditioned dynamical EVT for predictive maintenance | Draft manuscript | [dynamical-evt-pdm](https://github.com/DiogoRibeiro7/dynamical-evt-pdm) | [PDF](https://github.com/DiogoRibeiro7/dynamical-evt-pdm/blob/main/paper/main.pdf), [LaTeX](https://github.com/DiogoRibeiro7/dynamical-evt-pdm/blob/main/paper/main.tex) |
+| Behavioral sensing models and change-point workflows | Draft paper note | [behavioral-sensing-research](https://github.com/DiogoRibeiro7/behavioral-sensing-research) | [Paper markdown](https://github.com/DiogoRibeiro7/behavioral-sensing-research/blob/develop/paper.md), [bibliography](https://github.com/DiogoRibeiro7/behavioral-sensing-research/blob/develop/paper.bib) |
+| BMSSP-style shortest-path implementation notes | Draft research note | [bmssp](https://github.com/DiogoRibeiro7/bmssp) | [Paper markdown](https://github.com/DiogoRibeiro7/bmssp/blob/develop/paper/paper.md), [bibliography](https://github.com/DiogoRibeiro7/bmssp/blob/develop/paper/paper.bib) |
+
+## Reproducible Reports
+
+| Work | Status | Repository | Source |
+| --- | --- | --- | --- |
+| Minimum wages, productivity and inflation in Portugal, 1974-present | Reproducible empirical report | [portugal-minimum-wage-inflation](https://github.com/DiogoRibeiro7/portugal-minimum-wage-inflation) | [LaTeX](https://github.com/DiogoRibeiro7/portugal-minimum-wage-inflation/blob/main/report/main.tex), [bibliography](https://github.com/DiogoRibeiro7/portugal-minimum-wage-inflation/blob/main/report/references.bib) |
+| Configurational pathways to firm innovation across European macroregions | Reproducible fsQCA study | [europe-fsqca-innovation](https://github.com/DiogoRibeiro7/europe-fsqca-innovation) | [LaTeX](https://github.com/DiogoRibeiro7/europe-fsqca-innovation/blob/main/paper/main.tex), [bibliography](https://github.com/DiogoRibeiro7/europe-fsqca-innovation/blob/main/paper/references.bib) |
+| Portugal 2025 turnout and OECD trust data | Public article/data package | [democracy_missing_voters](https://github.com/DiogoRibeiro7/democracy_missing_voters) | [repository README](https://github.com/DiogoRibeiro7/democracy_missing_voters#readme) |
+| Portuguese external economic linkages, 1960-1973 | Reproducible research pipeline | [portugal-external-growth-1960-1973](https://github.com/DiogoRibeiro7/portugal-external-growth-1960-1973) | [repository README](https://github.com/DiogoRibeiro7/portugal-external-growth-1960-1973#readme) |
+| Portugal's public-debt interest burden | Reproducible analysis | [portugal-public-debt-interest](https://github.com/DiogoRibeiro7/portugal-public-debt-interest) | [repository README](https://github.com/DiogoRibeiro7/portugal-public-debt-interest#readme) |
+
+## Research-Code Companions
+
+These repositories support or reproduce research arguments but are primarily code companions rather than standalone manuscripts.
+
+- [brat-boosting](https://github.com/DiogoRibeiro7/brat-boosting) — Python implementation of Boulevard Regularized Additive regression Trees with statistical inference.
+- [sssp_research_lab](https://github.com/DiogoRibeiro7/sssp_research_lab) — Implementable shortest-path algorithms inspired by sorting-barrier SSSP research.
+- [adaptive-importance-sampling](https://github.com/DiogoRibeiro7/adaptive-importance-sampling) — Safe cross-entropy-based importance sampling for rare-event simulations.
+- [ann-variable-selection-refutation](https://github.com/DiogoRibeiro7/ann-variable-selection-refutation) — Reproduction and stress test of ANN variable selection from t-statistics.
+- [pca-cautionary-tale](https://github.com/DiogoRibeiro7/pca-cautionary-tale) — Reproducible PCA reliability workflow using PCA, t-SNE, persistent homology and cosine-distance modelling.
+
+## Inclusion Rule
+
+I list public repositories when they contain at least one of: manuscript source, PDF output, bibliography, notebooks, replication code, or a documented research report. Private repositories and unpublished work without public source are intentionally excluded.

--- a/_posts/2020-11-05-probability_theory_basics.md
+++ b/_posts/2020-11-05-probability_theory_basics.md
@@ -35,7 +35,7 @@ Probability theory provides the mathematical foundation for modeling uncertainty
 
 ## The Sample Space and Its Events
 
-Every probabilistic argument starts with a sample space $\Omega$, the set of all outcomes an experiment can produce. A single roll of a die has $\Omega = \{1,2,3,4,5,6\}$; a request to a web service might have $\Omega = \{\text{success}, \text{timeout}, \text{error}\}$. An *event* is any subset of $\Omega$, and a probability measure $P$ assigns each event a number in $[0,1]$ subject to three constraints:
+Every probabilistic argument starts with a sample space $\Omega$, the set of all outcomes an experiment can produce. A single roll of a die has $\Omega = \lbrace 1,2,3,4,5,6\rbrace$; a request to a web service might have $\Omega = \lbrace \text{success}, \text{timeout}, \text{error}\rbrace$. An *event* is any subset of $\Omega$, and a probability measure $P$ assigns each event a number in $[0,1]$ subject to three constraints:
 
 $$
 P(\Omega) = 1, \qquad P(A) \ge 0, \qquad

--- a/_posts/2025-08-03-optimizing_data_pipelines_apache_airflow.md
+++ b/_posts/2025-08-03-optimizing_data_pipelines_apache_airflow.md
@@ -1358,6 +1358,7 @@ alert_manager = IntelligentAlertManager()
 
 ### 4.3 Performance Analytics and Optimization
 
+{% raw %}
 ```python
 from airflow.models import TaskInstance, DagRun
 from airflow.utils.db import provide_session
@@ -1794,6 +1795,7 @@ class PerformanceAnalyzer:
 # Global performance analyzer
 performance_analyzer = PerformanceAnalyzer()
 ```
+{% endraw %}
 
 ## 5\. Scaling and High Availability Patterns
 

--- a/_posts/2026-07-01-dynamic_time_warping_time_series_clustering.md
+++ b/_posts/2026-07-01-dynamic_time_warping_time_series_clustering.md
@@ -1,0 +1,150 @@
+---
+permalink: '/time-series/dynamic_time_warping_time_series_clustering/'
+title: 'Dynamic Time Warping and Time Series Clustering'
+categories:
+- Time Series
+tags:
+- Time Series
+- Clustering
+- Unsupervised Learning
+- Python
+author_profile: false
+seo_title: 'Dynamic Time Warping and Clustering'
+seo_description: 'Euclidean distance fails when two series have the same shape at different speeds. How DTW aligns them, and what that means for clustering.'
+excerpt: >-
+  Two series can trace an identical shape while one runs slightly ahead of the
+  other. Point-by-point distance calls them dissimilar; dynamic time warping
+  does not.
+summary: >-
+  How dynamic time warping aligns series that differ in timing rather than
+  shape, why it is not a metric and what that costs, the constraints that make
+  it tractable, and how to cluster series sensibly once you have a distance
+  that reflects shape.
+keywords:
+  - dynamic time warping
+  - DTW
+  - time series clustering
+  - shape-based distance
+  - k-medoids
+classes: wide
+date: '2026-07-01'
+header:
+  image: /assets/images/data_science_1.jpg
+  og_image: /assets/images/data_science_1.jpg
+  overlay_image: /assets/images/data_science_1.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_1.jpg
+  twitter_image: /assets/images/data_science_1.jpg
+---
+Two machines run the same production cycle. One runs slightly faster. Their sensor traces have identical shape — same peaks, same troughs, same order — but at every instant the values differ, because one is a little ahead. Euclidean distance reports them as dissimilar. Any clustering built on that distance separates them.
+
+Dynamic time warping exists to fix exactly this: comparing series by shape rather than by simultaneity.
+
+## What Warping Means
+
+Euclidean distance pairs observation $i$ in one series with observation $i$ in the other, and only ever that pairing. DTW instead searches over all monotonic alignments — mappings that may stretch or compress the time axis — and returns the cost of the cheapest one.
+
+Formally, build the cost matrix $D$ where $D_{ij}$ accumulates the distance between prefix $i$ of the first series and prefix $j$ of the second:
+
+$$
+D_{ij} = d(x_i, y_j) + \min\left(D_{i-1,j},\ D_{i,j-1},\ D_{i-1,j-1}\right).
+$$
+
+Each step takes the cheapest way of arriving: consume a point from the first series, from the second, or from both. The final entry $D_{nm}$ is the DTW distance, and tracing the minimising path backwards recovers the alignment itself.
+
+Three constraints define a valid path. It starts at $(1,1)$ and ends at $(n,m)$ — **boundary**. It never moves backwards in either series — **monotonicity**. And it advances by at most one index at a time — **continuity**. Together these guarantee every observation is matched at least once and the ordering is preserved.
+
+```python
+import numpy as np
+
+def dtw(x, y, window=None):
+    """DTW distance with an optional Sakoe-Chiba band."""
+    n, m = len(x), len(y)
+    w = max(window or max(n, m), abs(n - m))
+    D = np.full((n + 1, m + 1), np.inf)
+    D[0, 0] = 0.0
+    for i in range(1, n + 1):
+        lo, hi = max(1, i - w), min(m, i + w)
+        for j in range(lo, hi + 1):
+            cost = (x[i - 1] - y[j - 1]) ** 2
+            D[i, j] = cost + min(D[i - 1, j], D[i, j - 1], D[i - 1, j - 1])
+    return np.sqrt(D[n, m])
+
+t = np.linspace(0, 2 * np.pi, 60)
+a = np.sin(t)
+b = np.sin(t * 1.15)          # same shape, running slightly faster
+c = np.sin(t) * 0.2           # same timing, much smaller amplitude
+
+euclid = lambda p, q: np.sqrt(((p - q) ** 2).sum())
+print(f"{'':12}{'euclidean':>11}{'DTW':>9}")
+print(f"{'a vs b':12}{euclid(a, b):11.3f}{dtw(a, b):9.3f}")
+print(f"{'a vs c':12}{euclid(a, c):11.3f}{dtw(a, c):9.3f}")
+```
+
+The comparison is the point. Series `b` differs from `a` only in speed and `c` differs only in amplitude. Euclidean distance treats the timing difference as substantial; DTW recognises the shapes as nearly identical while still keeping the genuinely different amplitude apart.
+
+## The Constraints That Make It Usable
+
+Unconstrained DTW has two problems.
+
+It is $O(nm)$ in time and memory, which becomes prohibitive on long series and on the all-pairs distance matrix that clustering requires.
+
+More subtly, unconstrained warping is *too* permissive: a single point in one series can be matched to a long stretch of the other, producing pathological alignments that map a brief spike onto an entire plateau.
+
+The **Sakoe-Chiba band** restricts the path to within $w$ steps of the diagonal, which both bounds the cost to $O(nw)$ and prevents degenerate alignments. The window size encodes a real assumption — how much timing distortion you believe exists — and small windows often perform *better* than large ones, not merely faster.
+
+For large-scale work, lower-bounding techniques such as LB_Keogh compute a cheap bound first and skip the full computation whenever the bound already exceeds the current best. This is what makes nearest-neighbour search over large collections tractable.
+
+## Why DTW Is Not a Metric
+
+DTW violates the triangle inequality. It is possible to have $d(x,z) > d(x,y) + d(y,z)$.
+
+That is not a technicality. Many algorithms assume a metric space: k-means relies on centroids being meaningful, and indexing structures such as ball trees and k-d trees require the triangle inequality to prune correctly. Using DTW with them is unsound, even though the code runs.
+
+The consequences for clustering are specific. **k-medoids** works, because it uses actual series as cluster centres and needs only a distance matrix. **Hierarchical clustering** works for the same reason. **k-means** does not work directly, because averaging series under DTW is not an ordinary mean — the correct analogue is DBA (DTW Barycentre Averaging), an iterative procedure that computes a consensus series under warping.
+
+```python
+from scipy.cluster.hierarchy import linkage, fcluster
+from scipy.spatial.distance import squareform
+
+rng = np.random.default_rng(0)
+# three groups: same shapes at different speeds and phases
+series, truth = [], []
+for g, (freq, amp) in enumerate([(1.0, 1.0), (1.0, 0.3), (2.0, 1.0)]):
+    for _ in range(8):
+        speed = rng.uniform(0.9, 1.1)
+        phase = rng.uniform(0, 0.4)
+        s = amp * np.sin(freq * speed * t + phase) + rng.normal(0, 0.05, t.size)
+        series.append(s); truth.append(g)
+series, truth = np.array(series), np.array(truth)
+
+n = len(series)
+Dm = np.zeros((n, n))
+for i in range(n):
+    for j in range(i + 1, n):
+        Dm[i, j] = Dm[j, i] = dtw(series[i], series[j], window=8)
+
+labels = fcluster(linkage(squareform(Dm), method="average"), 3, criterion="maxclust")
+purity = sum(np.bincount(truth[labels == k]).max() for k in np.unique(labels)) / n
+print(f"cluster purity against the true groups: {purity:.2f}")
+```
+
+Cluster purity is reported rather than accuracy because cluster labels are arbitrary — the algorithm has no obligation to number groups the way you did.
+
+## When Not to Use It
+
+DTW is the right tool when timing distortion is genuine and irrelevant to your question — gesture recognition, speech, repeated production cycles, gait analysis.
+
+It is the wrong tool when timing *is* the signal. If two patients' symptoms follow the same trajectory but one deteriorates twice as fast, warping the difference away discards the clinically important part. If you are aligning series that must stay on a shared calendar, warping is meaningless: January is January.
+
+DTW is also insensitive to amplitude scaling unless you normalise deliberately. Z-normalising each series first compares pure shape; leaving them raw keeps magnitude in play. Neither is right in general, and the choice should be explicit.
+
+A final caution from the classification literature: one-nearest-neighbour with DTW is a famously strong baseline that many elaborate methods fail to beat. Before reaching for something more sophisticated, run it.
+
+## References
+
+- Sakoe, H., & Chiba, S. (1978). Dynamic programming algorithm optimization for spoken word recognition. *IEEE Transactions on Acoustics, Speech, and Signal Processing*, 26(1), 43-49.
+- Keogh, E., & Ratanamahatana, C. A. (2005). Exact indexing of dynamic time warping. *Knowledge and Information Systems*, 7(3), 358-386.
+- Petitjean, F., Ketterlin, A., & Gançarski, P. (2011). A global averaging method for dynamic time warping, with applications to clustering. *Pattern Recognition*, 44(3), 678-693.
+- Aghabozorgi, S., Shirkhorshidi, A. S., & Wah, T. Y. (2015). Time-series clustering: a decade review. *Information Systems*, 53, 16-38.
+- Bagnall, A., Lines, J., Bostrom, A., Large, J., & Keogh, E. (2017). The great time series classification bake off. *Data Mining and Knowledge Discovery*, 31(3), 606-660.

--- a/_posts/2026-07-03-long_memory_fractional_integration_arfima.md
+++ b/_posts/2026-07-03-long_memory_fractional_integration_arfima.md
@@ -1,0 +1,146 @@
+---
+permalink: '/time-series/long_memory_fractional_integration_arfima/'
+title: 'Long Memory and Fractional Integration in Time Series'
+categories:
+- Time Series
+tags:
+- Time Series
+- Statistical Modeling
+- Statistics
+- Finance
+author_profile: false
+seo_title: 'Long Memory and Fractional Integration'
+seo_description: 'Some series are neither stationary nor unit-root. Fractional differencing sits between the two and explains slowly decaying autocorrelation.'
+excerpt: >-
+  Standard practice offers two options: the series is stationary, or you
+  difference it. Some series are genuinely in between, and forcing them either
+  way loses information.
+summary: >-
+  What long memory means, how the fractional differencing parameter
+  interpolates between stationarity and a unit root, how to estimate it, and
+  why hyperbolic rather than exponential decay in the autocorrelation function
+  is the signature to look for.
+keywords:
+  - long memory
+  - fractional integration
+  - ARFIMA
+  - Hurst exponent
+  - persistence
+classes: wide
+date: '2026-07-03'
+header:
+  image: /assets/images/data_science_3.jpg
+  og_image: /assets/images/data_science_3.jpg
+  overlay_image: /assets/images/data_science_3.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_3.jpg
+  twitter_image: /assets/images/data_science_3.jpg
+---
+Standard time series practice offers a binary choice. Either the series is stationary and you model it directly, or it has a unit root and you difference it. The Dickey-Fuller test decides which.
+
+Some series answer neither. Their autocorrelation decays too slowly for stationarity but too quickly for a random walk, and forcing them into either category discards real structure. Fractional integration describes the space in between.
+
+## Two Kinds of Decay
+
+The distinction is visible in how the autocorrelation function falls away.
+
+A stationary ARMA process has autocorrelation decaying **exponentially**: $\rho_k \sim \phi^k$. After a few dozen lags it is indistinguishable from zero, and shocks die out quickly.
+
+A long memory process has autocorrelation decaying **hyperbolically**: $\rho_k \sim k^{2d-1}$ for a parameter $d$. This is far slower. Autocorrelations remain measurably positive at lag 100, sometimes lag 1000, and the sum $\sum_k |\rho_k|$ diverges — which is the formal definition of long memory.
+
+The practical signature is a correlogram that declines steadily without ever quite reaching zero, combined with a Dickey-Fuller test that is ambiguous or rejects weakly.
+
+## Fractional Differencing
+
+Ordinary differencing applies the operator $(1-L)$ where $L$ is the lag operator. Differencing twice applies $(1-L)^2$. The integration order $d$ is a whole number by construction.
+
+Fractional integration allows $d$ to be any real value, defining $(1-L)^d$ through its binomial expansion:
+
+$$
+(1-L)^d = \sum_{k=0}^{\infty} \binom{d}{k}(-L)^k
+= 1 - dL - \frac{d(1-d)}{2}L^2 - \frac{d(1-d)(2-d)}{6}L^3 - \cdots
+$$
+
+For integer $d$ the series terminates and recovers ordinary differencing. For fractional $d$ it does not terminate: every past observation receives a weight, decaying slowly. That infinite, slowly decaying weighting is precisely what "long memory" means operationally.
+
+The parameter partitions the behaviour:
+
+| $d$ | Behaviour |
+|---|---|
+| $d = 0$ | Short memory; standard ARMA |
+| $d \in (0, 0.5)$ | Stationary with long memory |
+| $d \in [0.5, 1)$ | Non-stationary but mean-reverting |
+| $d = 1$ | Unit root; random walk |
+
+The range $d \in (0, 0.5)$ is the interesting one: the series is stationary, so standard asymptotics apply, yet shocks persist far longer than any ARMA model would allow.
+
+**ARFIMA($p,d,q$)** combines fractional differencing with ARMA terms, letting $d$ capture the long-run persistence while $p$ and $q$ handle short-run dynamics.
+
+```python
+import numpy as np
+
+def frac_diff_weights(d, n):
+    """Binomial expansion weights for (1-L)^d, truncated at n terms."""
+    w = np.zeros(n)
+    w[0] = 1.0
+    for k in range(1, n):
+        w[k] = w[k - 1] * (k - 1 - d) / k
+    return w
+
+for d in (0.0, 0.3, 0.5, 1.0):
+    w = frac_diff_weights(d, 6)
+    print(f"d={d}: weights {np.round(w, 4)}")
+
+# the filter weights and the process autocorrelation decay at DIFFERENT rates
+print("\nfilter weights |w_k| ~ k^(-d-1), at lag 100:")
+for d in (0.1, 0.3, 0.45):
+    print(f"  d={d}: {abs(frac_diff_weights(d, 200)[100]):.6f}")
+
+print("process autocorrelation rho_k ~ k^(2d-1), at lag 100:")
+for d in (0.1, 0.3, 0.45):
+    print(f"  d={d}: {100.0 ** (2 * d - 1):.5f}")
+```
+
+At $d = 1$ the weights are exactly $[1, -1, 0, 0, \dots]$, which is ordinary first differencing. At $d = 0$ they are $[1, 0, 0, \dots]$, leaving the series untouched. At fractional $d$ the expansion never terminates: every past observation receives a non-zero weight, and that is the operational meaning of long memory.
+
+Two decay rates are easy to confuse here, and the output separates them deliberately. The **filter** weights fall off as $k^{-d-1}$, so a larger $d$ makes them decay *faster*. The **process** autocorrelation falls off as $k^{2d-1}$, so a larger $d$ makes it decay *slower* — at lag 100, $d = 0.45$ still leaves a correlation around 0.63 while $d = 0.1$ has dropped to 0.03. It is the second quantity that carries the memory; the first is just the filter needed to remove it.
+
+## Estimating d
+
+Several approaches exist, differing in robustness and assumptions.
+
+The **rescaled range** statistic, from Hurst's work on Nile flooding, estimates the Hurst exponent $H$, related to the differencing parameter by $d = H - 0.5$. It is intuitive and known to be biased in small samples and sensitive to short-run correlation.
+
+The **GPH estimator** regresses the log periodogram on log frequency near zero, exploiting the fact that the spectral density of a long memory process diverges at the origin like $f(\lambda) \sim \lambda^{-2d}$. It is semiparametric, requiring no model for the short-run dynamics, at the cost of depending on how many frequencies you include.
+
+**Exact maximum likelihood** on a full ARFIMA specification is efficient when the model is right and sensitive to misspecification when it is not.
+
+A recurring difficulty deserves emphasis: **long memory and structural breaks are easy to confuse.** A stationary series with occasional level shifts produces slowly decaying sample autocorrelation that mimics long memory closely. Estimating $d$ from such a series yields a significant value that describes breaks rather than persistence. Testing for breaks before concluding long memory is not optional.
+
+## Where It Appears
+
+Long memory shows up consistently in a few domains.
+
+Financial **volatility** is the strongest case. Returns themselves are close to unpredictable, but absolute or squared returns show autocorrelation persisting over hundreds of days — which motivated FIGARCH and related fractionally integrated volatility models.
+
+**Hydrology** is where the phenomenon was first quantified. Hurst's analysis of Nile river levels found persistence that standard models could not reproduce, and the Hurst exponent carries his name for that reason.
+
+**Network traffic**, **inflation**, and some **climate series** also display it.
+
+In machine learning, fractional differencing has found a use worth noting: differencing a price series to stationarity destroys almost all of its memory, whereas fractional differencing with the smallest $d$ that achieves stationarity preserves considerably more information while satisfying the model's requirements.
+
+## Practical Cautions
+
+Do not conclude long memory from a slowly decaying correlogram alone — check for breaks and trends first, since both produce the same appearance.
+
+Be careful with forecasts. Long memory implies shocks persist, which makes long-horizon forecasts more sensitive to the estimated $d$ than to anything else in the model. Small errors in $d$ compound over the horizon.
+
+And weigh the cost. ARFIMA is harder to fit, harder to explain, and frequently no better than a well-specified short-memory model at short horizons. It earns its place when the persistence itself is the object of study — as in volatility modelling — rather than when it is a marginal accuracy improvement.
+
+## References
+
+- Granger, C. W. J., & Joyeux, R. (1980). An introduction to long-memory time series models and fractional differencing. *Journal of Time Series Analysis*, 1(1), 15-29.
+- Hosking, J. R. M. (1981). Fractional differencing. *Biometrika*, 68(1), 165-176.
+- Geweke, J., & Porter-Hudak, S. (1983). The estimation and application of long memory time series models. *Journal of Time Series Analysis*, 4(4), 221-238.
+- Baillie, R. T. (1996). Long memory processes and fractional integration in econometrics. *Journal of Econometrics*, 73(1), 5-59.
+- Diebold, F. X., & Inoue, A. (2001). Long memory and regime switching. *Journal of Econometrics*, 105(1), 131-159.

--- a/_posts/2026-07-05-count_time_series_poisson_autoregression.md
+++ b/_posts/2026-07-05-count_time_series_poisson_autoregression.md
@@ -1,0 +1,132 @@
+---
+permalink: '/time-series/count_time_series_poisson_autoregression/'
+title: 'Modelling Count Time Series'
+categories:
+- Time Series
+tags:
+- Time Series
+- Statistical Modeling
+- Probability
+- Predictive Maintenance
+author_profile: false
+seo_title: 'Modelling Count Time Series'
+seo_description: 'Counts that depend on their own history break both Poisson regression and ARIMA. What INGARCH and related models do instead.'
+excerpt: >-
+  Daily incident counts are integers, non-negative, often small, and
+  correlated with yesterday. ARIMA assumes none of that and Poisson regression
+  assumes independence.
+summary: >-
+  Why continuous time series models are wrong for counts and independent count
+  models are wrong for time series, how INGARCH makes the conditional mean
+  depend on past counts and past means, and how to handle overdispersion and
+  excess zeros.
+keywords:
+  - count time series
+  - INGARCH
+  - Poisson autoregression
+  - overdispersion
+  - integer-valued models
+classes: wide
+date: '2026-07-05'
+header:
+  image: /assets/images/data_science_4.jpg
+  og_image: /assets/images/data_science_4.jpg
+  overlay_image: /assets/images/data_science_4.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_4.jpg
+  twitter_image: /assets/images/data_science_4.jpg
+---
+Daily counts of equipment failures, hospital admissions, or security incidents share a shape that standard time series methods handle badly. The values are integers, non-negative, frequently small, and correlated with yesterday's value.
+
+ARIMA assumes a continuous, unbounded variable and will happily forecast −0.4 failures. Poisson regression respects the integer, non-negative structure and assumes observations are independent, which for a time series is exactly wrong.
+
+## Why the Obvious Fixes Fail
+
+The instinct is to transform. Taking $\log(y_t + 1)$ and fitting ARIMA is common and carries several problems: the constant is arbitrary and changes the answer, back-transforming introduces bias, and small counts remain visibly discrete after transformation.
+
+The other instinct is to ignore the discreteness because the counts are large. That is defensible: when counts run in the hundreds, the normal approximation is reasonable and ARIMA works acceptably. The problem is specific to *small* counts — under roughly 20 per period, and acutely under 5, where the discreteness and the non-negativity both bind.
+
+## INGARCH: Autoregression on the Conditional Mean
+
+The cleanest framework keeps a proper count distribution and makes its *mean* depend on the past.
+
+Let $y_t \mid \mathcal{F}_{t-1} \sim \text{Poisson}(\lambda_t)$, and model the conditional mean:
+
+$$
+\lambda_t = \omega + \sum_{i=1}^{p} \alpha_i y_{t-i} + \sum_{j=1}^{q} \beta_j \lambda_{t-j},
+$$
+
+with $\omega > 0$ and non-negative coefficients to keep $\lambda_t$ positive.
+
+The structure mirrors GARCH, which is where the name comes from: past observations feed back through $\alpha$, and past conditional means through $\beta$, giving persistence without requiring many lags. Stationarity requires $\sum \alpha_i + \sum \beta_j < 1$, exactly as in GARCH.
+
+Because the observation distribution is Poisson, forecasts are automatically non-negative integers with a proper predictive distribution — the thing ARIMA cannot provide for counts.
+
+A log-linear variant models $\log \lambda_t$ instead, which removes the positivity constraints on coefficients and allows negative feedback, at the cost of a less direct interpretation.
+
+```python
+import numpy as np
+
+def simulate_ingarch(n, omega=2.0, alpha=0.35, beta=0.4, seed=0):
+    """Poisson INGARCH(1,1): counts whose conditional mean is autoregressive."""
+    rng = np.random.default_rng(seed)
+    y = np.zeros(n, dtype=int)
+    lam = np.zeros(n)
+    lam[0] = omega / (1 - alpha - beta)          # unconditional mean
+    y[0] = rng.poisson(lam[0])
+    for t in range(1, n):
+        lam[t] = omega + alpha * y[t - 1] + beta * lam[t - 1]
+        y[t] = rng.poisson(lam[t])
+    return y, lam
+
+y, lam = simulate_ingarch(2000)
+print(f"mean count      : {y.mean():.2f}")
+print(f"variance        : {y.var(ddof=1):.2f}")
+print(f"dispersion index: {y.var(ddof=1) / y.mean():.2f}")
+print(f"lag-1 autocorr  : {np.corrcoef(y[:-1], y[1:])[0, 1]:.3f}")
+print(f"zeros           : {(y == 0).mean():.1%}")
+```
+
+Two properties of the output are worth noting. The lag-1 autocorrelation is substantial, which is the dependence a plain Poisson model would deny. And the dispersion index exceeds 1 even though the observation distribution is exactly Poisson — the autoregression in $\lambda_t$ induces overdispersion in the marginal counts by itself.
+
+That second point matters practically: observing variance greater than the mean does not prove you need a negative binomial. Serial dependence produces the same symptom.
+
+## Overdispersion and Excess Zeros
+
+When dispersion remains after accounting for the dynamics, the observation distribution needs widening. Replacing Poisson with a **negative binomial** adds a parameter so that
+
+$$
+\operatorname{Var}(y_t \mid \mathcal{F}_{t-1}) = \lambda_t + \frac{\lambda_t^2}{\theta},
+$$
+
+recovering Poisson as $\theta \to \infty$. Ignoring genuine overdispersion does not usually bias the fitted mean much, but it makes standard errors far too small and prediction intervals far too narrow.
+
+Excess zeros are a separate diagnosis. If more periods are zero than even an overdispersed model predicts, two structures are candidates. A **hurdle model** splits the problem into "is the count zero" and "given it is positive, how large" — appropriate when zeros arise from a distinct mechanism. A **zero-inflated model** mixes a point mass at zero with a count distribution, appropriate when some periods are structurally incapable of producing events.
+
+The distinction is substantive rather than technical. A machine that is switched off produces structural zeros; a machine that is running and simply did not fail produces sampling zeros. Only the first justifies zero inflation.
+
+## Alternatives Worth Knowing
+
+**INAR models** take a different route, defining autoregression through *thinning* rather than through the mean: each of yesterday's events survives to today with probability $\alpha$, plus new arrivals. This has a natural interpretation for populations and queues, where "survival" is a real mechanism, and it keeps everything integer-valued throughout.
+
+**GLMs with lagged covariates** are the pragmatic option: fit a Poisson or negative binomial GLM including lagged counts and rolling means as predictors. This is not a fully specified process model and it is easy to implement, easy to extend with exogenous variables, and often adequate.
+
+**State space models for counts** put a latent continuous process behind a count observation equation, which handles missing data and multiple sources of variation cleanly at the cost of more computation.
+
+## Practical Guidance
+
+Check the dispersion index first, but interpret it carefully — as above, dependence inflates it independently of the observation distribution.
+
+Plot the autocorrelation of the counts. If it is negligible, a plain GLM without dynamics is sufficient and the extra machinery is unnecessary.
+
+Choose the evaluation metric with the discreteness in mind. RMSE on small counts is dominated by whether the model predicts 0 or 1, and the honest evaluation is probabilistic: use the ranked probability score or the log score on the predictive distribution, which is available here precisely because the model specifies one.
+
+Finally, treat the exposure. If the periods differ in length or population at risk, include an offset — modelling counts without adjusting for exposure attributes to dynamics what is really variation in opportunity.
+
+## References
+
+- Ferland, R., Latour, A., & Oraichi, D. (2006). Integer-valued GARCH process. *Journal of Time Series Analysis*, 27(6), 923-942.
+- Fokianos, K., Rahbek, A., & Tjøstheim, D. (2009). Poisson autoregression. *Journal of the American Statistical Association*, 104(488), 1430-1439.
+- Liboschik, T., Fokianos, K., & Fried, R. (2017). tscount: an R package for analysis of count time series following generalized linear models. *Journal of Statistical Software*, 82(5), 1-51.
+- Weiß, C. H. (2018). *An Introduction to Discrete-Valued Time Series*. Wiley.
+- Cameron, A. C., & Trivedi, P. K. (2013). *Regression Analysis of Count Data* (2nd ed.). Cambridge University Press.

--- a/_posts/2026-07-07-neural_forecasting_architectures.md
+++ b/_posts/2026-07-07-neural_forecasting_architectures.md
@@ -1,0 +1,103 @@
+---
+permalink: '/time-series/neural_forecasting_architectures/'
+title: 'Neural Forecasting: What the Architectures Actually Do'
+categories:
+- Time Series
+tags:
+- Time Series
+- Neural Networks
+- Forecasting
+- Machine Learning
+author_profile: false
+seo_title: 'Neural Forecasting Architectures'
+seo_description: 'DeepAR, N-BEATS and Temporal Fusion Transformers, what each is built for, and when a gradient boosting baseline still wins.'
+excerpt: >-
+  Neural forecasting has produced genuinely useful architectures and a great
+  deal of noise. The differences between them are more interesting than their
+  benchmark scores.
+summary: >-
+  A practical comparison of the main neural forecasting architectures:
+  DeepAR's probabilistic autoregression, N-BEATS's interpretable basis
+  expansion, the Temporal Fusion Transformer's handling of covariates, and the
+  conditions under which none of them beats gradient boosting.
+keywords:
+  - neural forecasting
+  - DeepAR
+  - N-BEATS
+  - temporal fusion transformer
+  - deep learning forecasting
+classes: wide
+date: '2026-07-07'
+header:
+  image: /assets/images/data_science_5.jpg
+  og_image: /assets/images/data_science_5.jpg
+  overlay_image: /assets/images/data_science_5.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_5.jpg
+  twitter_image: /assets/images/data_science_5.jpg
+---
+Neural forecasting arrived with large claims and a poor early record. The M4 competition in 2018 saw pure deep learning entries beaten by statistical methods; the winner was a hybrid. Since then the architectures have improved substantially, and the useful question is no longer whether they work but what each is actually built to do.
+
+## DeepAR: Probabilistic Autoregression
+
+DeepAR trains a recurrent network across many related series at once, and its defining choice is the output: rather than predicting a value, it predicts the **parameters of a distribution** — the mean and variance of a Gaussian, or the parameters of a negative binomial for counts.
+
+Training maximises the likelihood of the observed data under those predicted parameters. Forecasting proceeds by sampling: draw a value from the predicted distribution, feed it back as input, predict the next step, repeat. Running many such paths gives a full predictive distribution rather than an interval bolted on afterwards.
+
+Two consequences follow. Because it is global, it forecasts new series with little history using learned patterns from related ones. And because the likelihood is explicit, the choice of distribution is a modelling decision you make deliberately — a negative binomial for counts rather than forcing a Gaussian onto data that cannot be negative.
+
+The autoregressive sampling is also its main weakness: errors compound along the path, and generation is sequential and therefore slow at long horizons.
+
+## N-BEATS: Basis Expansion, No Recurrence
+
+N-BEATS discards recurrence entirely. It is a deep stack of fully connected blocks, each producing two outputs: a **backcast** (its reconstruction of the input window) and a **forecast**. Each block subtracts its backcast from the input before passing the residual onward, so successive blocks model what earlier ones could not.
+
+This residual arrangement is the architectural idea, and it produces something unusual for a neural model: interpretability by construction. In the interpretable variant, blocks are constrained to specific basis functions — polynomial for trend, Fourier for seasonality — so the output decomposes into named components much like a classical decomposition.
+
+N-BEATS produces the whole horizon in one forward pass rather than step by step, avoiding compounding error and running considerably faster than autoregressive generation. It was the first pure deep learning model to beat the M4 winner on that benchmark.
+
+Its limitation is that the basic form is univariate and point-valued: it does not natively take covariates, and it does not produce a predictive distribution without additional machinery. NHITS extends it with multi-rate sampling that improves long-horizon performance.
+
+## Temporal Fusion Transformer: Covariates Taken Seriously
+
+The TFT is built around a distinction the other two mostly ignore: different kinds of input carry different information.
+
+It separates **static covariates** (product category, store location), **known-future inputs** (holidays, planned promotions, day of week — things you know in advance), and **observed past inputs** (things measured historically but unknown for the future). Most real forecasting problems have all three, and treating a known holiday calendar identically to an unknown past observation discards genuine information.
+
+Architecturally it combines an LSTM for local processing with attention over longer ranges, and adds variable selection networks that learn which inputs matter. It outputs quantiles directly, trained on pinball loss, so it is probabilistic without sampling.
+
+The attention weights and variable selection weights give some interpretability, though this should be read cautiously — attention weights are suggestive of importance, not a reliable attribution of it.
+
+## When None of Them Wins
+
+The M5 competition is the useful counterweight. It was dominated by **gradient boosting** with careful feature engineering, not by neural architectures. That result is not an anomaly, and the conditions under which it holds are predictable.
+
+Neural models need scale. Their advantage comes from learning shared structure across many series, and with a few dozen series there is not enough signal to justify the parameters. Below a few hundred related series, gradient boosting on lag features is usually both better and cheaper.
+
+They also need the relationships to be genuinely complex. If the structure is trend plus seasonality plus a few covariate effects, a linear model or ETS captures it, and additional capacity fits noise.
+
+And they cost considerably more: tuning, training time, and monitoring. A model that improves accuracy by 2% while adding a GPU dependency and a week of engineering may not be worth it, and that trade-off should be evaluated explicitly rather than assumed away.
+
+## Foundation Models
+
+The current direction is pretrained models — TimeGPT, Chronos, Moirai and others — trained on large collections of series and applied zero-shot to new ones.
+
+The appeal is obvious: no per-dataset training, and immediate forecasts for series with little history. Reported results are genuinely promising, and two cautions are warranted. Evaluation is difficult because the pretraining corpora are large and sometimes undocumented, so contamination with benchmark data is hard to rule out. And zero-shot performance on a specific domain with idiosyncratic structure is frequently worse than a small model trained on that domain.
+
+The reasonable position is to benchmark them against your own baselines rather than against published averages, which is the same discipline that applies to any new method.
+
+## A Sensible Order of Work
+
+Establish the baselines first — seasonal naive, ETS, and gradient boosting on lag features. These are fast, and they set the bar the neural model has to clear.
+
+Reach for neural forecasting when you have many related series, genuine need for probabilistic output, or covariates with the structure the TFT is designed around. Choose the architecture by what the problem needs: DeepAR for probabilistic counts across many series, N-BEATS for fast univariate point forecasts at long horizons, TFT when known-future covariates carry real information.
+
+And evaluate honestly, with rolling-origin validation, against those baselines, on the metric the decision actually depends on. The literature on this subject rewards scepticism: the gap between benchmark results and production performance has been wide, and the methods that survive contact with real data are usually the simpler ones.
+
+## References
+
+- Salinas, D., Flunkert, V., Gasthaus, J., & Januschowski, T. (2020). DeepAR: probabilistic forecasting with autoregressive recurrent networks. *International Journal of Forecasting*, 36(3), 1181-1191.
+- Oreshkin, B. N., Carpov, D., Chapados, N., & Bengio, Y. (2020). N-BEATS: neural basis expansion analysis for interpretable time series forecasting. *ICLR*.
+- Lim, B., Arık, S. Ö., Loeff, N., & Pfister, T. (2021). Temporal fusion transformers for interpretable multi-horizon time series forecasting. *International Journal of Forecasting*, 37(4), 1748-1764.
+- Makridakis, S., Spiliotis, E., & Assimakopoulos, V. (2022). M5 accuracy competition: results, findings, and conclusions. *International Journal of Forecasting*, 38(4), 1346-1364.
+- Zeng, A., Chen, M., Zhang, L., & Xu, Q. (2023). Are transformers effective for time series forecasting? *Proceedings of AAAI*, 37(9), 11121-11128.

--- a/_posts/2026-07-07-neural_forecasting_architectures.md
+++ b/_posts/2026-07-07-neural_forecasting_architectures.md
@@ -54,7 +54,7 @@ N-BEATS discards recurrence entirely. It is a deep stack of fully connected bloc
 
 This residual arrangement is the architectural idea, and it produces something unusual for a neural model: interpretability by construction. In the interpretable variant, blocks are constrained to specific basis functions — polynomial for trend, Fourier for seasonality — so the output decomposes into named components much like a classical decomposition.
 
-N-BEATS produces the whole horizon in one forward pass rather than step by step, avoiding compounding error and running considerably faster than autoregressive generation. It was the first pure deep learning model to beat the M4 winner on that benchmark.
+N-BEATS produces the whole horizon in one forward pass rather than step by step, avoiding compounding error and running considerably faster than autoregressive generation. Its authors report outperforming the M4 competition winner, which was notable because the deep learning entries to M4 itself had not managed that.
 
 Its limitation is that the basic form is univariate and point-valued: it does not natively take covariates, and it does not produce a predictive distribution without additional machinery. NHITS extends it with multi-rate sampling that improves long-horizon performance.
 

--- a/_posts/2026-07-09-temporal_hierarchies_cross_temporal_reconciliation.md
+++ b/_posts/2026-07-09-temporal_hierarchies_cross_temporal_reconciliation.md
@@ -90,7 +90,7 @@ $$
 
 with $S$ now encoding temporal rather than categorical summation.
 
-The reported benefit is consistent across studies: reconciled forecasts beat the base forecasts at *every* level, including the level each was optimised for. The monthly forecast improves because the annual forecast contributes information about trend that the monthly data alone estimates poorly, and the annual forecast improves because monthly data pins down the recent level more precisely.
+The reported benefit is that reconciled forecasts tend to improve on the base forecasts across levels, including the level each was optimised for — not merely at the levels that were incoherent. The monthly forecast improves because the annual forecast contributes information about trend that the monthly data alone estimates poorly, and the annual forecast improves because monthly data pins down the recent level more precisely.
 
 Reconciliation also handles a mundane but common organisational problem. Finance forecasts annually, operations forecast monthly, and the two numbers differ. Temporal reconciliation gives a principled way to align them rather than scaling one to match the other.
 

--- a/_posts/2026-07-09-temporal_hierarchies_cross_temporal_reconciliation.md
+++ b/_posts/2026-07-09-temporal_hierarchies_cross_temporal_reconciliation.md
@@ -1,0 +1,120 @@
+---
+permalink: '/time-series/temporal_hierarchies_cross_temporal_reconciliation/'
+title: 'Temporal Hierarchies: Reconciling Across Time Granularities'
+categories:
+- Time Series
+tags:
+- Time Series
+- Forecasting
+- Statistical Modeling
+- Supply Chain
+author_profile: false
+seo_title: 'Temporal Hierarchies in Forecasting'
+seo_description: 'Monthly forecasts rarely sum to the annual one. Temporal aggregation is a hierarchy too, and reconciling it improves accuracy.'
+excerpt: >-
+  A hierarchy does not have to be geographic. Aggregating a series over time
+  produces the same coherence problem, and the same machinery solves it.
+summary: >-
+  How temporal aggregation creates a forecasting hierarchy, why forecasts made
+  at different granularities disagree, how reconciling across them improves
+  accuracy at every level, and why aggregation attenuates noise while
+  preserving signal.
+keywords:
+  - temporal hierarchies
+  - temporal aggregation
+  - cross-temporal reconciliation
+  - THieF
+  - multi-granularity forecasting
+classes: wide
+date: '2026-07-09'
+header:
+  image: /assets/images/data_science_6.jpg
+  og_image: /assets/images/data_science_6.jpg
+  overlay_image: /assets/images/data_science_6.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_6.jpg
+  twitter_image: /assets/images/data_science_6.jpg
+---
+Hierarchical forecasting usually means a structure of products or regions. But aggregating a single series **over time** produces a hierarchy too: weekly totals sum to monthly, monthly to quarterly, quarterly to annual. Forecasts made at each granularity will not agree, and the same reconciliation machinery applies.
+
+## The Structure
+
+Take a monthly series. Aggregating pairs of months gives a bi-monthly series, aggregating four gives quarterly, twelve gives annual. Each level is a legitimate view of the same underlying process, and each supports its own forecast.
+
+The relationship is exactly the summing structure of a hierarchy: annual is the sum of quarters, each quarter the sum of months. What varies is that levels here are indexed by *aggregation period* rather than by category.
+
+The name for the combined structure is a **temporal hierarchy**, and the important claim about it is not merely that reconciliation enforces consistency, but that different levels contain genuinely different information.
+
+## Why Levels Disagree Informatively
+
+Temporal aggregation changes the signal-to-noise ratio, and it does so asymmetrically.
+
+Noise is largely independent across periods, so summing $k$ periods grows the noise standard deviation by roughly $\sqrt{k}$. Signal — trend, and any component persisting across periods — grows by $k$. The ratio therefore improves by about $\sqrt{k}$ with aggregation.
+
+This has a concrete consequence. **Trend is easier to see in aggregated data**, because the noise partially cancels. **Seasonality within the aggregation period disappears**, because summing a full cycle removes it. Annual totals show trend cleanly and say nothing about which month is busy; monthly data shows seasonality clearly and buries the trend in noise.
+
+Neither level is more correct. They are complementary, which is the argument for using both rather than choosing.
+
+```python
+import numpy as np
+
+rng = np.random.default_rng(0)
+n = 240                                        # 20 years of monthly data
+t = np.arange(n)
+signal = 100 + 0.4 * t + 20 * np.sin(2 * np.pi * t / 12)
+y = signal + rng.normal(0, 15, n)
+
+def aggregate(x, k):
+    m = len(x) // k
+    return x[:m * k].reshape(m, k).sum(axis=1)
+
+print(f"{'level':12}{'periods':>9}{'trend/noise':>13}")
+for k, name in [(1, "monthly"), (3, "quarterly"), (12, "annual")]:
+    agg = aggregate(y, k)
+    # slope estimated by OLS against its own index, relative to residual sd
+    idx = np.arange(len(agg))
+    slope = np.polyfit(idx, agg, 1)[0]
+    resid_sd = (agg - np.polyval(np.polyfit(idx, agg, 1), idx)).std(ddof=2)
+    print(f"{name:12}{len(agg):>9}{abs(slope) / resid_sd:>13.3f}")
+```
+
+The trend-to-noise ratio rises sharply with aggregation. The annual series has only 20 observations, and the trend in it is far more visible than in the 240 monthly ones — which is why an annual forecast can be more reliable about direction even with a twelfth of the data.
+
+## Reconciling Across Time
+
+Producing forecasts at every aggregation level and reconciling them uses the same projection as the cross-sectional case:
+
+$$
+\tilde{y} = S(S^\top W^{-1}S)^{-1}S^\top W^{-1}\hat{y},
+$$
+
+with $S$ now encoding temporal rather than categorical summation.
+
+The reported benefit is consistent across studies: reconciled forecasts beat the base forecasts at *every* level, including the level each was optimised for. The monthly forecast improves because the annual forecast contributes information about trend that the monthly data alone estimates poorly, and the annual forecast improves because monthly data pins down the recent level more precisely.
+
+Reconciliation also handles a mundane but common organisational problem. Finance forecasts annually, operations forecast monthly, and the two numbers differ. Temporal reconciliation gives a principled way to align them rather than scaling one to match the other.
+
+## Aggregation Also Changes the Model
+
+A less obvious effect: the appropriate model changes with the aggregation level. Temporal aggregation of an ARIMA process yields a different ARIMA process, and aggregation tends to attenuate autoregressive structure — heavily aggregated series often look close to white noise around a trend.
+
+This is a reason not to force one model family across all levels. Fitting each level independently with automatic model selection, then reconciling, generally works better than imposing a single specification.
+
+For intermittent demand the effect is particularly useful. A daily series that is 90% zeros becomes, at monthly aggregation, a series of modest counts with far fewer zeros — a much easier forecasting problem. Forecasting at the aggregated level and disaggregating is a standard technique for exactly this reason, and it is the temporal-hierarchy idea applied deliberately.
+
+## Practical Notes
+
+**Choose levels that divide evenly.** Weekly data does not aggregate cleanly into months, since months contain 4 or 5 weeks. Use levels with integer ratios — for monthly data, 1, 2, 3, 4, 6 and 12 all divide the year.
+
+**Watch the sample size at the top.** Twenty years of monthly data gives 20 annual observations, which is a thin basis for any model. The top level contributes information about trend but should not be over-trusted.
+
+**Aggregation and the forecast horizon interact.** If decisions are made monthly, a reconciled monthly forecast is what you need; the annual level is an input, not the output. Do not let the improved appearance of the aggregate series tempt you into planning at a granularity nobody acts on.
+
+**Combine with cross-sectional hierarchies carefully.** Reconciling across products *and* time simultaneously — cross-temporal reconciliation — is possible and substantially more complex, since the two structures interact. It is worth attempting only when both hierarchies genuinely matter for decisions.
+
+## References
+
+- Athanasopoulos, G., Hyndman, R. J., Kourentzes, N., & Petropoulos, F. (2017). Forecasting with temporal hierarchies. *European Journal of Operational Research*, 262(1), 60-74.
+- Kourentzes, N., Petropoulos, F., & Trapero, J. R. (2014). Improving forecasting by estimating time series structural components across multiple frequencies. *International Journal of Forecasting*, 30(2), 291-302.
+- Nikolopoulos, K., Syntetos, A. A., Boylan, J. E., Petropoulos, F., & Assimakopoulos, V. (2011). An aggregate-disaggregate intermittent demand approach (ADIDA). *Journal of the Operational Research Society*, 62(3), 544-554.
+- Wickramasuriya, S. L., Athanasopoulos, G., & Hyndman, R. J. (2019). Optimal forecast reconciliation for hierarchical and grouped time series through trace minimization. *Journal of the American Statistical Association*, 114(526), 804-819.

--- a/_posts/2026-07-11-forecast_value_added_analysis.md
+++ b/_posts/2026-07-11-forecast_value_added_analysis.md
@@ -1,0 +1,133 @@
+---
+permalink: '/time-series/forecast_value_added_analysis/'
+title: 'Forecast Value Added: Is Your Process Helping?'
+categories:
+- Time Series
+tags:
+- Forecasting
+- Time Series
+- Model Evaluation
+- Business Intelligence
+author_profile: false
+seo_title: 'Forecast Value Added Analysis'
+seo_description: 'Every step in a forecasting process is assumed to add accuracy. FVA measures whether it does, and often the answer is no.'
+excerpt: >-
+  Forecasting processes accumulate steps: a statistical model, a planner
+  override, a consensus meeting. Each is assumed to improve the number. FVA is
+  how you find out.
+summary: >-
+  What forecast value added measures, how to construct the comparison against
+  a naive baseline and against each preceding process step, why judgmental
+  overrides frequently destroy accuracy, and how to run the analysis without
+  it becoming an audit of individuals.
+keywords:
+  - forecast value added
+  - FVA
+  - judgmental adjustment
+  - forecasting process
+  - demand planning
+classes: wide
+date: '2026-07-11'
+header:
+  image: /assets/images/data_science_7.jpg
+  og_image: /assets/images/data_science_7.jpg
+  overlay_image: /assets/images/data_science_7.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_7.jpg
+  twitter_image: /assets/images/data_science_7.jpg
+---
+A demand planning process typically has several stages. A statistical model produces a baseline. A planner reviews and adjusts it. Sales adds market intelligence. A consensus meeting settles the final number. Each stage exists because someone believes it improves accuracy.
+
+Forecast Value Added asks whether it does, by measuring accuracy after each stage against accuracy before it. The results are frequently uncomfortable.
+
+## The Comparison
+
+FVA is a difference in accuracy attributable to a process step:
+
+$$
+\text{FVA} = \text{Accuracy}_{\text{after step}} - \text{Accuracy}_{\text{before step}} .
+$$
+
+Two comparisons matter, and both are needed.
+
+**Against the naive forecast.** Does the statistical model beat "same as last period" — or the seasonal naive where seasonality exists? If not, the entire modelling apparatus is subtracting value, and the honest response is to ship the naive forecast.
+
+**Against the preceding step.** Does the planner's override improve on the statistical baseline? Does the consensus number improve on the planner's? Each stage is judged against the thing it modified, not against the naive.
+
+The output is conventionally a stairstep table:
+
+| Process step | MAPE | FVA vs naive | FVA vs previous |
+|---|---|---|---|
+| Naive forecast | 28.4% | — | — |
+| Statistical model | 22.1% | +6.3 | +6.3 |
+| Planner override | 23.6% | +4.8 | −1.5 |
+| Consensus forecast | 22.9% | +5.5 | +0.7 |
+
+This shape — the model helps, the override hurts, the meeting partially repairs the damage — is common enough in published FVA studies to be the expected result rather than a surprising one.
+
+```python
+import numpy as np
+
+rng = np.random.default_rng(0)
+n = 500
+actual = 100 + rng.normal(0, 12, n)
+
+naive = np.roll(actual, 1); naive[0] = actual[0]
+statistical = actual + rng.normal(0, 8, n)                  # genuinely useful
+# planner override: small real signal, larger added noise
+override = statistical + rng.normal(1.5, 7, n)
+consensus = 0.6 * statistical + 0.4 * override
+
+def mape(f):
+    return np.mean(np.abs((actual - f) / actual)) * 100
+
+steps = [("naive", naive), ("statistical", statistical),
+         ("planner override", override), ("consensus", consensus)]
+
+base = mape(naive)
+prev = base
+print(f"{'step':20}{'MAPE':>8}{'vs naive':>10}{'vs prev':>9}")
+for name, f in steps:
+    m = mape(f)
+    print(f"{name:20}{m:7.2f}%{base - m:+10.2f}{prev - m:+9.2f}")
+    prev = m
+```
+
+The negative column is the one that changes behaviour. A step with consistently negative FVA is consuming analyst time to make the forecast worse, and that is a finding a process owner can act on.
+
+## Why Judgmental Overrides Often Hurt
+
+The empirical literature is fairly consistent: manual adjustments to statistical forecasts have mixed value, and a large share destroy accuracy.
+
+Several mechanisms explain it. Planners adjust too often, treating every forecast as needing intervention, when most need none. Small adjustments in particular tend to be noise — the evidence suggests large adjustments, made for a specific known reason, are more likely to help than routine tinkering.
+
+Adjustments are also asymmetric. Upward revisions are more common and less accurate than downward ones, which is consistent with optimism and with incentives that penalise stockouts more visibly than excess inventory.
+
+And planners often adjust for information the model already contains. Reacting to a seasonal peak that the seasonal component has already captured double-counts it.
+
+The useful distinction is between information the model *cannot* have — a competitor's announced exit, a confirmed one-off order, a plant closure — and pattern-reading that the model does better. Overrides restricted to the first category tend to add value; overrides applied routinely do not.
+
+## Running the Analysis Without Blame
+
+FVA is a process diagnostic, and it fails the moment it becomes a performance review. If planners believe the analysis will be used against them, they stop recording their reasoning, and the data needed to improve the process disappears.
+
+Some practices that keep it useful. Report at the level of the process step, aggregated across planners, rather than naming individuals. Require a recorded reason for each override, which both improves the adjustments and makes the analysis interpretable. Frame a negative FVA as "this step is not where our effort pays off" rather than as an error. And act on the finding by removing or narrowing the step, which is the point — an FVA report that changes nothing is wasted work.
+
+## Practical Considerations
+
+**Use a scaled or absolute metric, not MAPE, where series differ in scale.** MAPE breaks near zero and penalises over- and under-forecasting asymmetrically, which biases the comparison. MASE is the safer default for cross-series aggregation.
+
+**Segment the results.** A process step can add value on high-volume, stable items and destroy it on intermittent ones. A single average conceals that, and the actionable conclusion is usually "keep overrides for the top 200 SKUs, automate the rest".
+
+**Use enough history.** Forecast accuracy is noisy, and a difference measured over a handful of periods will not replicate. Several months of forecast-actual pairs at minimum, and treat small differences as inconclusive rather than as findings.
+
+**Compare like with like.** All steps must be measured on the same items, the same periods, and the same forecast horizon — an override made at a shorter lead time has an unfair advantage over the statistical forecast it modified.
+
+The underlying question FVA poses is worth asking of any analytical process, not only forecasting: which of these steps would we notice if we stopped doing it?
+
+## References
+
+- Gilliland, M. (2010). *The Business Forecasting Deal: Exposing Myths, Eliminating Bad Practices, Providing Practical Solutions*. Wiley.
+- Fildes, R., Goodwin, P., Lawrence, M., & Nikolopoulos, K. (2009). Effective forecasting and judgmental adjustments. *International Journal of Forecasting*, 25(1), 3-23.
+- Syntetos, A. A., Nikolopoulos, K., Boylan, J. E., Fildes, R., & Goodwin, P. (2009). The effects of integrating management judgement into intermittent demand forecasts. *International Journal of Production Economics*, 118(1), 72-81.
+- Hyndman, R. J., & Koehler, A. B. (2006). Another look at measures of forecast accuracy. *International Journal of Forecasting*, 22(4), 679-688.

--- a/_posts/2026-07-11-forecast_value_added_analysis.md
+++ b/_posts/2026-07-11-forecast_value_added_analysis.md
@@ -54,7 +54,7 @@ Two comparisons matter, and both are needed.
 
 **Against the preceding step.** Does the planner's override improve on the statistical baseline? Does the consensus number improve on the planner's? Each stage is judged against the thing it modified, not against the naive.
 
-The output is conventionally a stairstep table:
+The output is conventionally a stairstep table. The figures below are illustrative rather than from the worked example that follows:
 
 | Process step | MAPE | FVA vs naive | FVA vs previous |
 |---|---|---|---|

--- a/_posts/2026-07-13-interrupted_time_series_causal_impact.md
+++ b/_posts/2026-07-13-interrupted_time_series_causal_impact.md
@@ -1,0 +1,126 @@
+---
+permalink: '/time-series/interrupted_time_series_causal_impact/'
+title: 'Interrupted Time Series and Causal Impact'
+categories:
+- Time Series
+tags:
+- Time Series
+- Correlation
+- Statistical Modeling
+- Experimental Design
+author_profile: false
+seo_title: 'Interrupted Time Series and Causal Impact'
+seo_description: 'You cannot randomise a policy change. Interrupted time series and synthetic controls estimate its effect from what came before.'
+excerpt: >-
+  A intervention happened at a known date and you need its effect. There is no
+  control group, only the series itself before and after, and the
+  counterfactual has to be constructed.
+summary: >-
+  How to estimate the effect of an intervention when randomisation is
+  impossible: segmented regression for level and slope changes, the
+  assumptions the counterfactual rests on, Bayesian structural time series
+  with control series, and the confounders that make a result unsafe.
+keywords:
+  - interrupted time series
+  - causal impact
+  - segmented regression
+  - synthetic control
+  - counterfactual
+classes: wide
+date: '2026-07-13'
+header:
+  image: /assets/images/data_science_8.jpg
+  og_image: /assets/images/data_science_8.jpg
+  overlay_image: /assets/images/data_science_8.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_8.jpg
+  twitter_image: /assets/images/data_science_8.jpg
+---
+A speed limit changed on 1 March. A new triage protocol started in January. A feature shipped on a Tuesday. In each case you need the effect of the intervention, and randomisation was never possible — the change applied to everyone at once.
+
+What you have is the series itself, before and after. The whole problem is constructing what *would* have happened without the intervention.
+
+## Segmented Regression
+
+The standard approach fits a regression with terms that allow the series to change level and slope at a known date:
+
+$$
+y_t = \beta_0 + \beta_1 t + \beta_2 D_t + \beta_3 (t - T_0) D_t + \varepsilon_t,
+$$
+
+where $D_t$ is 1 after the intervention and $T_0$ is the intervention time. The coefficients separate two distinct effects:
+
+- $\beta_1$ — the pre-intervention slope.
+- $\beta_2$ — an **immediate level change** at the intervention.
+- $\beta_3$ — a **change in slope** afterwards.
+
+Distinguishing these matters substantively. A policy producing a one-off drop that then resumes the old trajectory is very different from one that changes the trajectory itself, and a model with only a level term will misattribute the second as the first.
+
+```python
+import numpy as np
+
+rng = np.random.default_rng(0)
+n, T0 = 120, 60
+t = np.arange(n)
+D = (t >= T0).astype(float)
+
+# truth: pre-slope 0.5, level drop of -8 at T0, slope changes to 0.5 - 0.3
+y = (50 + 0.5 * t - 8 * D - 0.3 * (t - T0) * D + rng.normal(0, 2.5, n))
+
+X = np.column_stack([np.ones(n), t, D, (t - T0) * D])
+beta, *_ = np.linalg.lstsq(X, y, rcond=None)
+names = ["intercept", "pre-slope", "level change", "slope change"]
+truth = [50, 0.5, -8, -0.3]
+for nm, b, tr in zip(names, beta, truth):
+    print(f"{nm:15}{b:8.3f}   (true {tr})")
+
+# the counterfactual: what the pre-trend alone predicts after T0
+counterfactual = beta[0] + beta[1] * t
+effect = (y - counterfactual)[T0:].mean()
+print(f"\nmean effect after intervention: {effect:.2f}")
+```
+
+The counterfactual here is simply the pre-intervention trend extended forward. That is the entire inferential content of the method, and it is where the assumptions live.
+
+## What the Counterfactual Assumes
+
+The estimate is only as good as the claim that, absent the intervention, the pre-existing trend would have continued. Several things break that.
+
+**Concurrent events.** If anything else changed at the same time, its effect is indistinguishable from the intervention's. A speed limit introduced alongside a public safety campaign confounds the two permanently — no amount of modelling separates them.
+
+**Regression to the mean.** Interventions are frequently triggered *by* an extreme observation. If a protocol changed because incidents spiked, some of the subsequent decline would have happened anyway. This is one of the most common ways interrupted time series overstates an effect.
+
+**Autocorrelation.** Residuals in a time series are correlated, so ordinary standard errors are too small and significance is overstated. Newey-West standard errors, or explicitly modelling the error as ARIMA, is not optional here.
+
+**Seasonality.** Comparing a post-intervention winter against a pre-intervention summer attributes the season to the policy. Seasonal terms must be in the model, or the comparison must span whole cycles.
+
+**Anticipation and phase-in.** If behaviour changed before the official date because the change was announced, or the policy rolled out gradually, a sharp break at $T_0$ is the wrong specification.
+
+## Adding a Control Series
+
+The strongest version of this design uses a comparison series that was *not* subject to the intervention but responds to the same background conditions — a neighbouring region, an untreated product line, a similar hospital.
+
+The counterfactual then comes from the control's behaviour rather than from extrapolating a trend, which handles concurrent shocks that affect both. This is the logic of difference-in-differences, and it rests on the **parallel trends** assumption: the two series would have moved together absent the intervention. That assumption is checkable before the intervention and untestable after, which is exactly its weakness.
+
+**Bayesian structural time series**, as implemented in CausalImpact, formalises this. It fits a state space model to the pre-period using control series as regressors, projects it forward, and reports the difference from the observed post-period with credible intervals. Its advantages are that it handles trend and seasonality explicitly, propagates uncertainty properly, and can select among many candidate controls.
+
+**Synthetic control** goes further, constructing a weighted combination of untreated units that best reproduces the treated unit's pre-intervention path, then using that combination as the counterfactual. It suits the case of one treated unit and many candidate controls — a single region, state, or country.
+
+## Reading a Result Honestly
+
+Three questions separate a credible estimate from a decorated coincidence.
+
+Does the pre-period fit well, and over a long enough window to establish the trend? A counterfactual extrapolated from six observations is a guess.
+
+Would the effect survive a placebo test? Running the same analysis on a fake intervention date, or on a control series that received no intervention, should produce nothing. If it produces an "effect", the method is finding structure that is not causal.
+
+Is the effect large relative to the pre-period variability? Interrupted time series has low power for small effects, and a modest shift in a noisy series will not be distinguishable no matter how the model is specified.
+
+Interrupted time series is a genuinely useful design when randomisation is impossible, and it is weaker than a randomised experiment in a specific way worth stating plainly: it assumes the future would have resembled the past, and that assumption is never verifiable for the period you care about.
+
+## References
+
+- Bernal, J. L., Cummins, S., & Gasparrini, A. (2017). Interrupted time series regression for the evaluation of public health interventions. *International Journal of Epidemiology*, 46(1), 348-355.
+- Brodersen, K. H., Gallusser, F., Koehler, J., Remy, N., & Scott, S. L. (2015). Inferring causal impact using Bayesian structural time-series models. *Annals of Applied Statistics*, 9(1), 247-274.
+- Abadie, A., Diamond, A., & Hainmueller, J. (2010). Synthetic control methods for comparative case studies. *Journal of the American Statistical Association*, 105(490), 493-505.
+- Wagner, A. K., Soumerai, S. B., Zhang, F., & Ross-Degnan, D. (2002). Segmented regression analysis of interrupted time series studies in medication use research. *Journal of Clinical Pharmacy and Therapeutics*, 27(4), 299-309.

--- a/_posts/2026-07-15-nowcasting_mixed_frequency_data.md
+++ b/_posts/2026-07-15-nowcasting_mixed_frequency_data.md
@@ -1,0 +1,128 @@
+---
+permalink: '/time-series/nowcasting_mixed_frequency_data/'
+title: 'Nowcasting with Mixed-Frequency Data'
+categories:
+- Time Series
+tags:
+- Time Series
+- Economics
+- Forecasting
+- Statistical Modeling
+author_profile: false
+seo_title: 'Nowcasting with Mixed-Frequency Data'
+seo_description: 'GDP is quarterly and published late. Daily indicators are available now. Mixed-frequency methods combine them without throwing information away.'
+excerpt: >-
+  The quantity you care about arrives quarterly and two months late. Related
+  indicators arrive daily. Nowcasting is the problem of estimating the present
+  from what has already been published.
+summary: >-
+  How to combine data sampled at different frequencies: why aggregating to the
+  lowest frequency discards most of the information, how MIDAS regressions
+  weight high-frequency observations parametrically, and how state space
+  models handle ragged-edge data naturally.
+keywords:
+  - nowcasting
+  - mixed frequency
+  - MIDAS
+  - ragged edge
+  - high-frequency indicators
+classes: wide
+date: '2026-07-15'
+header:
+  image: /assets/images/data_science_9.jpg
+  og_image: /assets/images/data_science_9.jpg
+  overlay_image: /assets/images/data_science_9.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_9.jpg
+  twitter_image: /assets/images/data_science_9.jpg
+---
+GDP for the current quarter is published weeks after the quarter ends. Meanwhile, electricity consumption, card transactions, freight movements and job postings are all available daily. Nowcasting is the problem of estimating the low-frequency quantity you care about, now, from the high-frequency data that has already arrived.
+
+The name is deliberate: this is not forecasting the future so much as estimating a present that has not yet been measured.
+
+## Two Structural Difficulties
+
+**Mixed frequencies.** The target is quarterly; the indicators are monthly or daily. The naive fix — aggregating everything to quarterly — throws away most of the information, and specifically the most recent part of it.
+
+**The ragged edge.** Different series are published with different lags. At any moment you have complete daily data up to yesterday, monthly data up to last month, and the previous quarter's GDP. The end of the dataset is jagged rather than square, and most estimation routines expect a rectangle.
+
+Any usable method has to handle both.
+
+## Bridge Equations
+
+The simplest approach aggregates high-frequency indicators to the target frequency and regresses:
+
+$$
+y_t^{Q} = \alpha + \beta \bar{x}_t^{Q} + \varepsilon_t .
+$$
+
+This is easy and it discards timing information. Aggregating three months into one quarterly average treats a strong January and a weak March identically to the reverse, and for nowcasting that distinction is exactly what matters.
+
+Bridge equations remain useful as a baseline and because they are transparent, which counts for something when the output feeds a policy discussion.
+
+## MIDAS
+
+Mixed Data Sampling regression keeps the high-frequency observations distinct and weights them with a parsimonious function:
+
+$$
+y_t = \alpha + \beta \sum_{j=0}^{J} w_j(\theta)\, x_{t - j/m} + \varepsilon_t .
+$$
+
+The insight is in $w_j(\theta)$. Estimating a free coefficient per high-frequency lag would require estimating dozens of parameters from a handful of quarterly observations. Instead the weights are constrained to a smooth parametric family — commonly the exponential Almon or a beta density — controlled by two or three parameters.
+
+The estimated weight profile is interpretable in its own right: it shows how far back the indicator matters and whether recent observations dominate, which is often the substantive question.
+
+```python
+import numpy as np
+
+def beta_weights(J, t1, t2):
+    """Normalised beta weights over J high-frequency lags."""
+    x = (np.arange(1, J + 1) - 0.5) / J
+    w = x ** (t1 - 1) * (1 - x) ** (t2 - 1)
+    return w / w.sum()
+
+for name, (a, b) in {"recent-heavy": (1.0, 5.0),
+                     "flat":         (1.0, 1.0),
+                     "hump":         (2.0, 3.0)}.items():
+    w = beta_weights(12, a, b)
+    print(f"{name:14} first 4 lags {np.round(w[:4], 3)}  "
+          f"share in first quarter of lags: {w[:3].sum():.2f}")
+```
+
+The three profiles express different beliefs about how information decays. A recent-heavy profile concentrates almost all weight on the most recent observations; a flat one is equivalent to simple averaging, which is the bridge equation. MIDAS lets the data choose between them rather than imposing the flat case by default.
+
+## State Space Models and Dynamic Factors
+
+The most flexible approach treats the problem as one of missing data.
+
+Put the high- and low-frequency series in a single state space model where the low-frequency observation is simply *unobserved* in the intervening periods. The Kalman filter then handles the ragged edge natively: run the prediction step where nothing is observed, run the update wherever something is. No aggregation, no alignment, no imputation.
+
+For many indicators, a **dynamic factor model** extracts a small number of common factors driving them all, and the target is related to those factors. This addresses the practical reality that nowcasting inputs number in the dozens or hundreds and are heavily correlated with each other.
+
+This combination — a dynamic factor model in state space form, updated by the Kalman filter — is what central banks generally use, and its defining practical feature is that the nowcast updates continuously as each new release arrives.
+
+## News, Not Levels
+
+The most useful output of a nowcasting system is not the number itself but the **decomposition of its revision**.
+
+When the nowcast moves from 1.8% to 2.1%, the informative question is which release caused the change. Formally, the revision decomposes into contributions from the "news" in each release — the difference between what was published and what the model expected to be published.
+
+An indicator that comes in exactly as expected contributes nothing, however important it is in general. A surprise in a minor indicator can move the nowcast substantially. This framing is what makes a nowcast a monitoring tool rather than a periodic number, and it also identifies which releases are worth watching.
+
+## Practical Cautions
+
+**Use vintage data for evaluation.** Macroeconomic series are revised, sometimes heavily. Backtesting against final revised values overstates accuracy badly, because the model is being given numbers that were not available at the time. Real-time vintage databases exist for exactly this reason.
+
+**Publication lags must be respected in the backtest.** Simulating a nowcast for a past date requires reconstructing what had actually been published by then, not simply truncating the dataset.
+
+**More indicators is not automatically better.** Highly correlated inputs add estimation error without adding information, which is the argument for factor extraction over throwing everything into a regression.
+
+**Check against a simple benchmark.** A constant, or a simple autoregression on the target, is the baseline. Nowcasting systems are elaborate, and it is worth confirming that the elaboration is buying accuracy rather than complexity.
+
+## References
+
+- Ghysels, E., Santa-Clara, P., & Valkanov, R. (2004). The MIDAS touch: mixed data sampling regression models. Working paper, UNC and UCLA.
+- Bańbura, M., Giannone, D., Modugno, M., & Reichlin, L. (2013). Now-casting and the real-time data flow. In *Handbook of Economic Forecasting* (Vol. 2A). Elsevier.
+- Giannone, D., Reichlin, L., & Small, D. (2008). Nowcasting: the real-time informational content of macroeconomic data. *Journal of Monetary Economics*, 55(4), 665-676.
+- Mariano, R. S., & Murasawa, Y. (2003). A new coincident index of business cycles based on monthly and quarterly series. *Journal of Applied Econometrics*, 18(4), 427-443.
+- Andreou, E., Ghysels, E., & Kourtellos, A. (2013). Should macroeconomic forecasters use daily financial data? *Journal of Business & Economic Statistics*, 31(2), 240-251.

--- a/_posts/2026-07-17-regime_switching_models_time_series.md
+++ b/_posts/2026-07-17-regime_switching_models_time_series.md
@@ -42,7 +42,7 @@ Regime-switching models allow the parameters themselves to change, with the regi
 
 ## The Markov-Switching Structure
 
-Let $S_t \in \{1, \dots, K\}$ be an unobserved regime. Conditional on it, the observation follows a regime-specific model — in the simplest case a different mean and variance:
+Let $S_t \in \lbrace 1, \dots, K\rbrace$ be an unobserved regime. Conditional on it, the observation follows a regime-specific model — in the simplest case a different mean and variance:
 
 $$
 y_t \mid S_t = k \sim \mathcal{N}(\mu_k, \sigma_k^2).

--- a/_posts/2026-07-17-regime_switching_models_time_series.md
+++ b/_posts/2026-07-17-regime_switching_models_time_series.md
@@ -1,0 +1,138 @@
+---
+permalink: '/time-series/regime_switching_models_time_series/'
+title: 'Regime-Switching Models for Time Series'
+categories:
+- Time Series
+tags:
+- Time Series
+- Statistical Modeling
+- Economics
+- Stochastic Processes
+author_profile: false
+seo_title: 'Regime-Switching Models'
+seo_description: 'Some series do not have one set of dynamics. Markov switching models let the parameters change with an unobserved state.'
+excerpt: >-
+  A single model fitted across a recession and an expansion describes neither.
+  Regime-switching models allow the dynamics themselves to change, with the
+  regime inferred rather than assumed.
+summary: >-
+  How Markov-switching models let parameters vary with an unobserved regime,
+  how the filter infers regime probabilities from the data, the difference
+  between a regime switch and a structural break, and the identification
+  problems that make these models easy to overfit.
+keywords:
+  - regime switching
+  - Markov switching
+  - hidden state
+  - structural break
+  - nonlinear time series
+classes: wide
+date: '2026-07-17'
+header:
+  image: /assets/images/data_science_10.jpg
+  og_image: /assets/images/data_science_10.jpg
+  overlay_image: /assets/images/data_science_10.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_10.jpg
+  twitter_image: /assets/images/data_science_10.jpg
+---
+Fit one model across a recession and an expansion and it describes neither. The mean growth rate, the volatility, and often the autocorrelation all differ between the two, and a single parameter set averages across regimes that behave differently.
+
+Regime-switching models allow the parameters themselves to change, with the regime treated as an unobserved state inferred from the data rather than assumed from a calendar.
+
+## The Markov-Switching Structure
+
+Let $S_t \in \{1, \dots, K\}$ be an unobserved regime. Conditional on it, the observation follows a regime-specific model — in the simplest case a different mean and variance:
+
+$$
+y_t \mid S_t = k \sim \mathcal{N}(\mu_k, \sigma_k^2).
+$$
+
+The regime evolves as a Markov chain with transition probabilities
+
+$$
+P(S_t = j \mid S_{t-1} = i) = p_{ij},
+$$
+
+collected in a transition matrix whose rows sum to one.
+
+The diagonal entries carry most of the interpretation. A value of $p_{11} = 0.95$ means that, once in regime 1, the process stays there with 95% probability each period, implying an expected duration of $1/(1 - p_{11}) = 20$ periods. High diagonals produce persistent regimes; low ones produce rapid switching that is usually a sign of a misspecified model.
+
+The crucial difference from a **structural break** is that regimes recur. A break is a permanent, one-off change in the data generating process. A regime is a state the series can return to, which is what makes recessions, high-volatility periods and machine operating modes natural applications.
+
+```python
+import numpy as np
+
+def simulate_markov_switching(n, mus, sigmas, P, seed=0):
+    rng = np.random.default_rng(seed)
+    K = len(mus)
+    s = np.zeros(n, dtype=int)
+    y = np.zeros(n)
+    s[0] = 0
+    for t in range(n):
+        if t > 0:
+            s[t] = rng.choice(K, p=P[s[t - 1]])
+        y[t] = rng.normal(mus[s[t]], sigmas[s[t]])
+    return y, s
+
+P = np.array([[0.97, 0.03],
+              [0.10, 0.90]])          # regime 0 persistent, regime 1 less so
+y, s = simulate_markov_switching(3000, mus=[0.8, -1.5],
+                                 sigmas=[1.0, 2.5], P=P)
+
+print(f"time in regime 0 : {(s == 0).mean():.1%}")
+print(f"expected duration: {1/(1-P[0,0]):.0f} and {1/(1-P[1,1]):.0f} periods")
+print(f"overall mean/sd  : {y.mean():.2f} / {y.std():.2f}")
+for k in (0, 1):
+    print(f"  regime {k}: mean {y[s==k].mean():+.2f}  sd {y[s==k].std():.2f}")
+```
+
+Note what the pooled statistics conceal. The overall mean of 0.26 sits between the regime means of +0.80 and −1.50 and describes neither. The overall standard deviation of 1.82 likewise falls between the regimes' 1.00 and 2.59, inflated above the calm regime by the variation *between* regimes rather than within them.
+
+A single-regime model fitted here would report a volatility of 1.82: too high for the 76% of the time the series spends in the calm state, and far too low for the turbulent one. That is the specific failure regime-switching addresses — not that the average is wrong, but that no period actually looks like the average.
+
+## Inferring the Regime
+
+Since $S_t$ is unobserved, estimation uses a filter closely analogous to the Kalman filter, alternating prediction and update on the regime *probabilities* rather than on a continuous state.
+
+At each step, the predicted regime distribution is propagated through the transition matrix, then updated by how likely the new observation is under each regime. Hamilton's filter does this recursively, and the likelihood accumulates as a by-product, which is what parameter estimation maximises. The parameters are usually fitted by EM or by direct numerical maximisation.
+
+The output is a **smoothed probability** of being in each regime at each time — not a hard classification. That probabilistic output is more useful than a label: a period with 55% probability of recession is genuinely ambiguous, and reporting it as "recession" discards that.
+
+## Where These Models Are Used
+
+**Business cycles.** Hamilton's original application modelled US GNP with two regimes and recovered dates close to the official NBER recession chronology, from the data alone.
+
+**Volatility regimes.** Financial returns switch between calm and turbulent periods, and a two-state model captures the clustering that a constant-variance model cannot.
+
+**Condition monitoring.** Equipment operating in distinct modes — idle, normal load, high load — produces sensor data with mode-specific dynamics, and inferring the mode is often useful in itself.
+
+**Energy demand.** Behaviour differs qualitatively between heating and cooling seasons in ways a smooth seasonal term represents poorly.
+
+## The Ways These Models Fail
+
+They are easy to fit and easy to over-fit, and three problems recur.
+
+**Label switching.** The likelihood is invariant to permuting regime labels, so "regime 1" in one run may be "regime 2" in another. Identification requires imposing an ordering constraint — for example, that $\mu_1 < \mu_2$ — otherwise results are not comparable across runs.
+
+**Choosing K.** Standard likelihood ratio tests do not apply, because under the null of fewer regimes the extra parameters are unidentified, which invalidates the usual asymptotics. Information criteria are the common fallback, and they favour more regimes than are interpretable. Two or three states is usually the practical limit before the regimes stop meaning anything.
+
+**Local optima.** The likelihood surface is multimodal, so results depend on starting values. Multiple random starts are necessary, and reporting only the best fit without noting the spread across starts is misleading.
+
+There is also a genuine identification concern raised in the literature: long memory and regime switching can generate similar autocorrelation patterns, so a series with occasional regime shifts can be mistaken for a long-memory process and vice versa. Distinguishing them from data alone is difficult, and the choice is often better made on substantive grounds — does the domain have recurring states? — than on statistical ones.
+
+## Practical Guidance
+
+Start with two regimes and a constant transition matrix. Add complexity only when the simple version demonstrably fails, since each addition multiplies the identification problems.
+
+Check that the estimated regimes correspond to something recognisable. If regime 2 occurs in scattered single periods with no interpretation, the model is fitting outliers rather than states, and a heavy-tailed single-regime model is the better description.
+
+Report smoothed probabilities rather than hard assignments, and be careful about forecasting: multi-step forecasts must average over the future regime path, so prediction intervals are wider — and often multimodal — compared with a single-regime model. That multimodality is informative and should not be summarised away.
+
+## References
+
+- Hamilton, J. D. (1989). A new approach to the economic analysis of nonstationary time series and the business cycle. *Econometrica*, 57(2), 357-384.
+- Hamilton, J. D. (1994). *Time Series Analysis*. Princeton University Press.
+- Kim, C.-J., & Nelson, C. R. (1999). *State-Space Models with Regime Switching*. MIT Press.
+- Diebold, F. X., & Inoue, A. (2001). Long memory and regime switching. *Journal of Econometrics*, 105(1), 131-159.
+- Ang, A., & Timmermann, A. (2012). Regime changes and financial markets. *Annual Review of Financial Economics*, 4, 313-337.

--- a/_posts/2026-07-19-forecast_combination_why_averaging_wins.md
+++ b/_posts/2026-07-19-forecast_combination_why_averaging_wins.md
@@ -1,0 +1,142 @@
+---
+permalink: '/time-series/forecast_combination_why_averaging_wins/'
+title: 'Forecast Combination: Why Averaging Usually Wins'
+categories:
+- Time Series
+tags:
+- Forecasting
+- Time Series
+- Model Evaluation
+- Statistical Modeling
+author_profile: false
+seo_title: 'Forecast Combination and Why It Works'
+seo_description: 'Combining forecasts beats picking the best one, reliably enough that it is one of the most replicated results in forecasting.'
+excerpt: >-
+  Choosing the best model is the obvious strategy. Averaging several is
+  usually better, and the reason is not that the average is smarter but that
+  it is less wrong in a specific way.
+summary: >-
+  Why combining forecasts reduces error, the bias-variance argument behind it,
+  why simple averages are hard to beat with estimated weights, when
+  combination fails, and how to choose a pool of models that are worth
+  combining.
+keywords:
+  - forecast combination
+  - forecast averaging
+  - ensemble forecasting
+  - combination puzzle
+  - model selection
+classes: wide
+date: '2026-07-19'
+header:
+  image: /assets/images/data_science_2.jpg
+  og_image: /assets/images/data_science_2.jpg
+  overlay_image: /assets/images/data_science_2.jpg
+  show_overlay_excerpt: false
+  teaser: /assets/images/data_science_2.jpg
+  twitter_image: /assets/images/data_science_2.jpg
+---
+You have five forecasts and have to ship one number. The obvious move is to identify the best model on validation data and use it. The better move, replicated across half a century of forecasting research, is usually to average them.
+
+## Why an Average Beats the Average Member
+
+The mechanism is not subtle once written down. Take two unbiased forecasts with error variances $\sigma_1^2$ and $\sigma_2^2$ and correlation $\rho$. The simple average has variance
+
+$$
+\operatorname{Var}\left(\frac{e_1 + e_2}{2}\right)
+= \frac{\sigma_1^2 + \sigma_2^2 + 2\rho\sigma_1\sigma_2}{4}.
+$$
+
+With equal variances this simplifies to $\frac{\sigma^2(1+\rho)}{2}$. Whenever $\rho < 1$ the combination has lower error variance than either component. At $\rho = 0$ it halves.
+
+The combination is not smarter than its members. It is less exposed to any single model's particular way of being wrong, and errors that are not perfectly correlated partially cancel.
+
+There is a second, more important effect. Model selection is itself estimated from finite data, so the "best" model on validation is partly best by luck. Choosing it commits fully to that luck; averaging hedges against it. The gain from combination is largest exactly when you are least certain which model is best — which is most of the time.
+
+```python
+import numpy as np
+
+rng = np.random.default_rng(0)
+n = 4000
+truth = rng.normal(0, 1, n)
+
+# three forecasts with different biases, variances and error correlation
+e1 = rng.normal(0.0, 1.0, n)
+e2 = rng.normal(0.2, 1.3, n)
+e3 = 0.4 * e1 + rng.normal(0.0, 0.9, n)      # correlated with the first
+f = np.array([truth + e1, truth + e2, truth + e3])
+
+rmse = lambda p: np.sqrt(((p - truth) ** 2).mean())
+for i, p in enumerate(f, 1):
+    print(f"model {i}      RMSE = {rmse(p):.4f}")
+print(f"best single   RMSE = {min(rmse(p) for p in f):.4f}")
+print(f"simple mean   RMSE = {rmse(f.mean(axis=0)):.4f}")
+print(f"median        RMSE = {rmse(np.median(f, axis=0)):.4f}")
+print("\nerror correlations:\n", np.corrcoef([e1, e2, e3]).round(2))
+```
+
+The average beats every individual model, including the best one — and it does so without knowing in advance which that was.
+
+## The Forecast Combination Puzzle
+
+Theory says optimal weights exist: weight inversely by error variance, accounting for covariance. In practice, simple equal weights routinely beat estimated optimal weights. This is the **forecast combination puzzle**, and it has been observed consistently since the 1970s.
+
+The explanation is estimation error. Optimal weights require estimating variances and covariances from a limited sample, and those estimates are noisy. The noise in the weights can easily exceed the benefit of weighting correctly, particularly with many models or short histories. Equal weighting estimates nothing and therefore contributes no estimation error at all.
+
+The practical implication is a default: **start with the simple average and require any weighting scheme to demonstrate improvement out of sample.** Approaches that shrink estimated weights toward equality often capture most of the theoretical benefit while avoiding most of the estimation cost.
+
+```python
+half = n // 2
+errs_train = (f - truth)[:, :half]
+
+# inverse-variance weights, estimated on the first half only
+inv = 1.0 / errs_train.var(axis=1)
+w = inv / inv.sum()
+
+# evaluate both schemes on the held-out second half
+rmse_oos = lambda p: np.sqrt(((p[half:] - truth[half:]) ** 2).mean())
+weighted = (w[:, None] * f).sum(axis=0)
+equal = f.mean(axis=0)
+
+print("estimated weights :", w.round(3))
+print(f"weighted RMSE (out of sample) = {rmse_oos(weighted):.4f}")
+print(f"equal    RMSE (out of sample) = {rmse_oos(equal):.4f}")
+```
+
+The puzzle shows up in the output. The inverse-variance weights are sensible — roughly 0.38, 0.23, 0.39, correctly down-weighting the worst model — and they still lose to equal weighting out of sample, 0.7202 against 0.7177. The weights were estimated from 2,000 observations, which is generous by real standards, and the estimation error still ate the theoretical gain.
+
+## Choosing What to Combine
+
+Since the benefit depends on error correlation, the pool matters more than the weighting.
+
+Combining five variants of the same ARIMA achieves little — their errors are nearly identical, so $\rho$ approaches 1 and the variance reduction vanishes. Combining an exponential smoothing model, a gradient boosting model on lag features, and a seasonal naive achieves much more, because each fails in a different way.
+
+Two practical guidelines follow. Prefer diversity of *method* over quantity of models. And do not exclude a weaker model automatically: a model with higher standalone error but uncorrelated errors can still improve the combination. What matters is marginal contribution, not individual rank.
+
+The median is worth considering alongside the mean. It is more robust when one model occasionally produces a wild forecast, which happens more often in automated pipelines than accuracy tables suggest — a single failed fit can otherwise drag the mean badly.
+
+## When Combination Does Not Help
+
+Three situations limit it.
+
+**Correlated errors.** If all models share a blind spot — none of them knows about a promotion — averaging preserves the blind spot exactly. Combination reduces variance, not shared bias.
+
+**A genuinely dominant model.** When one method is clearly correct and the others are misspecified, averaging drags the good forecast toward the bad ones. This is rarer than practitioners assume, and it should be demonstrated rather than believed.
+
+**Interpretability requirements.** A combined forecast is hard to explain. "Why did the number change?" has a clean answer for one model and a diffuse one for an ensemble, which matters when a planner must defend the figure.
+
+Note also that combining *point* forecasts is not the same as combining distributions. Averaging quantiles from several models does not generally produce a calibrated predictive distribution — the linear pool of densities is typically overdispersed. Probabilistic combination is a distinct problem with its own literature.
+
+## What to Do
+
+Fit a small, deliberately diverse set of models. Take the simple average, and treat that as the number to beat. Compare it against the best individual model and against any weighting scheme, all on the same out-of-sample periods. Adopt weights only when they win by a margin large enough to survive the next data update.
+
+The M4 and M5 competitions both reinforced this: the top entries were combinations, not single models, and elaborate weighting was not what separated them.
+
+## References
+
+- Bates, J. M., & Granger, C. W. J. (1969). The combination of forecasts. *Operational Research Quarterly*, 20(4), 451-468.
+- Clemen, R. T. (1989). Combining forecasts: a review and annotated bibliography. *International Journal of Forecasting*, 5(4), 559-583.
+- Smith, J., & Wallis, K. F. (2009). A simple explanation of the forecast combination puzzle. *Oxford Bulletin of Economics and Statistics*, 71(3), 331-355.
+- Timmermann, A. (2006). Forecast combinations. In *Handbook of Economic Forecasting* (Vol. 1). Elsevier.
+- Makridakis, S., Spiliotis, E., & Assimakopoulos, V. (2020). The M4 competition: 100,000 time series and 61 forecasting methods. *International Journal of Forecasting*, 36(1), 54-74.

--- a/_posts/2026-08-11-probabilistic_forecasting_quantiles_pinball_loss.md
+++ b/_posts/2026-08-11-probabilistic_forecasting_quantiles_pinball_loss.md
@@ -101,7 +101,7 @@ The check that matters is the last line: at each $\tau$ the lowest pinball loss 
 
 Several routes lead to a predictive distribution.
 
-**Fit one model per quantile.** Gradient boosting libraries accept a quantile objective directly, so training at $\tau \in \{0.1, 0.5, 0.9\}$ gives three models describing the distribution's shape. Simple and flexible; the drawback is that independently fitted quantiles can **cross** — the predicted 90th percentile falling below the 50th — which is incoherent and needs sorting or a monotonicity constraint.
+**Fit one model per quantile.** Gradient boosting libraries accept a quantile objective directly, so training at $\tau \in \lbrace 0.1, 0.5, 0.9\rbrace$ gives three models describing the distribution's shape. Simple and flexible; the drawback is that independently fitted quantiles can **cross** — the predicted 90th percentile falling below the 50th — which is incoherent and needs sorting or a monotonicity constraint.
 
 **Use a parametric model's own intervals.** ARIMA and exponential smoothing in state space form produce prediction intervals from their error variance. These are principled but depend on the model's distributional assumption, usually normality, which understates the tails of most real demand.
 

--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 layout: home
 author_profile: true
 title: "Diogo Ribeiro"
-seo_title: "Diogo Ribeiro — Statistics, Machine Learning & Applied Mathematics"
+seo_title: "Statistics, Machine Learning and Applied Mathematics"
 seo_description: "Research, technical articles and open-source software on statistical modelling, machine learning, time series, data systems and applied mathematics."
 header:
   overlay_image: /assets/images/data_has_better_idea.jpg
 ---
 
-<h1>Diogo Ribeiro — Statistics, Machine Learning &amp; Applied Mathematics</h1>
+<h2>Statistics, Machine Learning &amp; Applied Mathematics</h2>
 
 <p>Research, technical articles and open-source software on statistical modelling, machine learning, time series, data systems and applied mathematics.</p>
 
@@ -16,6 +16,7 @@ header:
 
 <p>
   <a class="btn btn--primary" href="/about/">About and editorial standards</a>
+  <a class="btn" href="/papers/">Papers and research</a>
   <a class="btn" href="/packages/">Projects and packages</a>
 </p>
 

--- a/packages/gensurvpy/search.html
+++ b/packages/gensurvpy/search.html
@@ -88,6 +88,7 @@
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
            <div itemprop="articleBody">
              
+  <h1>Search</h1>
   <noscript>
   <div id="fallback" class="admonition warning">
     <p class="last">


### PR DESCRIPTION
Five new project pages under `/packages/` (pinn-rk, pinnlab, setqca, tscv-vision, wifi-activity-recognition) plus a `/papers/` page for research repositories, both linked from the main navigation.

The packages index now links to these internal pages rather than straight out to PyPI, so the site keeps the visitor and each project gets an indexable page of its own. `index.html` drops its in-body `h1` to `h2`, leaving one `h1` per page.

**Verified against the built site:** builds clean; all 8 internal package links resolve; all 7 navigation links resolve; each new page has exactly one `h1`, a Twitter card and a description.

**Two metadata problems found and fixed while checking** — both on *pages* rather than posts, which my usual post audit doesn't cover:

| | before | after |
|---|---|---|
| `/packages/` meta description | 198 chars | 129 |
| home page `seo_title` | 66 chars | 52 |

Both were being truncated in search results.

Note this branch also carries #393's commits, since it was branched from that work — merge #393 first, or this PR will bring both.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five internal package pages and a new Papers page, and routes navigation and the packages index to them so visitors stay on-site and projects get indexable pages. Previously the packages index linked to PyPI; now it links to internal pages. Pages adopt a single-H1 structure and tighter SEO metadata.

**Reviewer focus**
- Navigation: `_data/navigation.yml` adds “Papers” → verify `/papers/` renders.
- Package pages: new `_pages/package-*.md` for `pinn-rk`, `pinnlab`, `setqca`, `tscv-vision`, `wifi-activity-recognition` → verify links, one H1, and `seo_title`/`seo_description`.
- Packages index: `_pages/packages.md` now links to internal pages; meta description shortened.
- Site headings/SEO: `index.html` demotes the body heading to `<h2>`; `packages/gensurvpy/search.html` adds an `<h1>` → confirm one H1 per page.
- Additional content: ten time-series posts added; two posts adjusted for inline math brace rendering and one code block wrapped with `{% raw %}`—these can be reviewed independently.

**Rollout**
- No migrations. Build the site and verify: the five `/packages/*` pages, `/packages/` index links, and `/papers/` all resolve from the main nav.

<sup>Written for commit f59628767da489bfa7ddf480d610041d73bfb551. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/DiogoRibeiro7.github.io/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

